### PR TITLE
docs(fr): ajouter le guide utilisateur complet “VITTE LIGHT” — doc.md (GitHub-friendly) + doc.html (stylé, Pages-ready)

### DIFF
--- a/docs/doc.md
+++ b/docs/doc.md
@@ -1,2021 +1,1068 @@
-
-VITTE LIGHT — GUIDE UTILISATEUR COMPLET
-Révision: 2025-09-05
-──────────────────────────────────────────────
-
-0) INTRODUCTION — VITTE LIGHT
-─────────────────────────────
-Vitte Light (abrégé **VITL**) est un langage minimaliste, dérivé du langage Vitte, 
-conçu pour allier **syntaxe moderne**, **simplicité d’usage** et **outillage complet**.  
-Il vise trois profils de développeurs : débutants, intermédiaires, professionnels.
-
-─────────────────────────────
-0.1 Philosophie du langage
-─────────────────────────────
-— Minimalisme : garder un cœur réduit de fonctionnalités, faciles à apprendre.  
-— Cohérence : syntaxe claire, pas de règles cachées, erreurs explicites.  
-— Polyvalence : exécution immédiate via VM, compilation native, intégration en C.  
-— Sécurité : gestion mémoire déterministe (références comptées), 
-  erreurs explicites (Result, panic).  
-— Portabilité : fonctionne sur Linux, BSD, macOS, Windows.  
-
-─────────────────────────────
-0.2 Pour qui est fait VITL ?
-─────────────────────────────
-**Débutant**  
-— Découvrir la programmation avec une syntaxe simple et lisible.  
-— Ne pas se perdre dans la complexité (pointeurs, mémoire manuelle, GC lourd).  
-— Apprendre progressivement des concepts modernes : immutabilité, Result, match.  
-
-**Développeur intermédiaire**  
-— Écrire des scripts rapides et compacts pour automatiser des tâches.  
-— Construire de petites applications CLI portables.  
-— Profiter d’un formateur, d’un linter et de tests intégrés.  
-
-**Professionnel**  
-— Compiler en exécutable natif optimisé (-O3).  
-— Exploiter le FFI C stable pour réutiliser des bibliothèques existantes.  
-— Intégrer VITL dans des workflows CI/CD et packager des outils distribuables.  
-— Inspecter IR et bytecode (`--emit-ir`, `--emit-bytecode`) pour analyser la compilation.  
-
-─────────────────────────────
-0.3 Domaines d’utilisation
-─────────────────────────────
-1. **Écriture rapide de scripts CLI**  
-   — Remplacer Bash/Python dans certains cas avec un langage typé.  
-   — Automatiser des tâches système, parser des fichiers, manipuler du texte.  
-
-2. **Compilation en exécutables natifs**  
-   — Créer de petits binaires autonomes, rapides à exécuter.  
-   — Idéal pour distribution, packaging, embarqué.  
-   — Compatible multi-plateformes (Linux, BSD, macOS, Windows).  
-
-3. **Langage embarqué (FFI C)**  
-   — Intégrer VITL dans des projets existants en C.  
-   — Charger du code utilisateur compilé en bytecode `.vitbc`.  
-   — Fournir un langage de script extensible pour un moteur ou un outil.  
-
-─────────────────────────────
-0.4 Points forts de VITL
-─────────────────────────────
-✓ Syntaxe lisible et unifiée (identique à Vitte).  
-✓ Gestion mémoire simple et prévisible (Rc/Weak).  
-✓ Erreurs explicites avec `Result` et propagation `?`.  
-✓ Standard library (I/O, fichiers, chaînes, maths, temps, vecteurs).  
-✓ Outils intégrés : formateur (`fmt`), linter (`check`), tests (`test`), doc (`doc`).  
-✓ Exécution directe ou compilation native optimisée.  
-✓ FFI C stable et facile à utiliser.  
-
-─────────────────────────────
-0.5 Exemple rapide (Hello World)
-─────────────────────────────
-Code :
-  module app.main
-  import std.io
-
-  fn main() -> i32 {
-    std.io::println("Bonjour Vitte Light")
-    return 0
+<!doctype html>
+<html lang="fr">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>VITTE LIGHT — Guide utilisateur complet (Révision 2025-09-05)</title>
+<meta name="color-scheme" content="light dark" />
+<style>
+  :root{
+    --bg:#ffffff; --fg:#0f172a; --muted:#64748b; --card:#f8fafc;
+    --border:#e2e8f0; --accent:#2563eb; --code:#111827;
   }
+  @media (prefers-color-scheme: dark){
+    :root{
+      --bg:#0b1020; --fg:#e8eef6; --muted:#9aa7bd; --card:#0f152a;
+      --border:#1f2a44; --accent:#60a5fa; --code:#e6edf3;
+    }
+  }
+  *{box-sizing:border-box}
+  body{
+    margin:0; background:var(--bg); color:var(--fg);
+    font:16px/1.7 system-ui,-apple-system,Segoe UI,Roboto,Inter,Arial,"Noto Sans";
+  }
+  a{ color:var(--accent); text-decoration:none }
+  a:hover{ text-decoration:underline }
+  header{
+    padding:24px; border-bottom:1px solid var(--border);
+    background:linear-gradient(180deg, rgba(99,102,241,.08), transparent);
+  }
+  .container{ max-width:1000px; margin:0 auto; padding:24px }
+  .intro{ display:flex; gap:18px; align-items:flex-end; flex-wrap:wrap }
+  h1{ margin:0; font-size:clamp(24px,3vw,36px); letter-spacing:.2px }
+  .rev{ color:var(--muted) }
+  nav.toc{
+    background:var(--card); border:1px solid var(--border); border-radius:12px;
+    padding:14px 16px; margin:20px 0 8px 0;
+  }
+  nav.toc strong{ font-size:13px; color:var(--muted); text-transform:uppercase; letter-spacing:.08em }
+  nav.toc ul{ margin:8px 0 0 0; padding:0 0 0 16px }
+  section{ margin:28px 0 }
+  h2{ margin:0 0 10px 0; padding-top:10px; border-top:1px solid var(--border) }
+  h3{ margin:18px 0 8px 0 }
+  p{ margin:.6rem 0 }
+  ul,ol{ margin:.4rem 0 .8rem 1.25rem }
+  .card{
+    background:var(--card); border:1px solid var(--border); border-radius:12px; padding:16px;
+  }
+  code{
+    font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,Monaco,monospace;
+    background:color-mix(in srgb, var(--card) 85%, transparent);
+    color:var(--code); padding:.15em .35em; border-radius:6px; border:1px solid var(--border)
+  }
+  pre{
+    margin:.75rem 0; padding:14px 16px; border-radius:12px;
+    background:var(--card); border:1px solid var(--border); overflow:auto
+  }
+  pre code{ background:transparent; border:0; padding:0; color:var(--code) }
+  hr{ border:0; border-top:1px dashed var(--border); margin:16px 0 }
+  .note{ color:var(--muted); font-size:.95rem }
+</style>
+</head>
+<body>
+  <header>
+    <div class="container intro">
+      <h1>VITTE LIGHT — Guide utilisateur complet</h1>
+      <span class="rev">Révision&nbsp;: 2025-09-05</span>
+    </div>
+  </header>
 
-Exécution :
-  vitl run src/main.vitl
+  <main class="container">
+    <nav class="toc" aria-label="Table des matières">
+      <strong>Sommaire</strong>
+      <ul>
+        <li><a href="#intro">0) Introduction</a>
+          <ul>
+            <li><a href="#philosophie">0.1 Philosophie</a></li>
+            <li><a href="#pour-qui">0.2 Pour qui&nbsp;?</a></li>
+            <li><a href="#domaines">0.3 Domaines d'utilisation</a></li>
+            <li><a href="#points-forts">0.4 Points forts</a></li>
+            <li><a href="#hello">0.5 Exemple rapide</a></li>
+          </ul>
+        </li>
+        <li><a href="#structure">1) Structure de projet</a></li>
+        <li><a href="#cli">2) Outils en ligne de commande</a></li>
+        <li><a href="#syntaxe">3) Syntaxe : découverte progressive</a></li>
+        <li><a href="#exemples">4) Premiers exemples</a></li>
+        <li><a href="#memoire">5) Mémoire et sécurité</a></li>
+        <li><a href="#erreurs">6) Gestion des erreurs</a></li>
+        <li><a href="#ffi">7) Interopérabilité C (FFI)</a></li>
+        <li><a href="#stdlib">8) Stdlib — aperçu</a></li>
+        <li><a href="#style">9) Style et bonnes pratiques</a></li>
+        <li><a href="#niveaux">10) Conseils par niveau</a></li>
+        <li><a href="#limites">11) Limites (version Light)</a></li>
+        <li><a href="#codes-sortie">12) Codes de sortie</a></li>
+        <li><a href="#diagnostics">13) Diagnostics courants</a></li>
+        <li><a href="#checklist">14) Checklist avant de livrer</a></li>
+      </ul>
+    </nav>
 
-Compilation :
-  vitl build -O2 -o build/app src/main.vitl
-  ./build/app
+    <!-- 0) INTRO -->
+    <section id="intro">
+      <h2>0) Introduction — VITTE LIGHT</h2>
+      <p><strong>Vitte Light</strong> (abrégé <strong>VITL</strong>) est un langage minimaliste, dérivé du langage Vitte, conçu pour allier <strong>syntaxe moderne</strong>, <strong>simplicité d’usage</strong> et <strong>outillage complet</strong>. Il vise trois profils de développeurs&nbsp;: débutants, intermédiaires, professionnels.</p>
 
-─────────────────────────────
-Résumé
-— **Débutant** : apprendre la programmation moderne sans complexité inutile.  
-— **Intermédiaire** : écrire des scripts compacts, robustes et portables.  
-— **Pro** : bénéficier d’un compilateur performant, d’un FFI C stable et d’une toolchain complète.  
-— Trois usages principaux : scripting CLI, compilation native, intégration embarquée.  
+      <section id="philosophie">
+        <h3>0.1 Philosophie du langage</h3>
+        <ul>
+          <li><strong>Minimalisme</strong>&nbsp;: garder un cœur réduit de fonctionnalités, faciles à apprendre.</li>
+          <li><strong>Cohérence</strong>&nbsp;: syntaxe claire, pas de règles cachées, erreurs explicites.</li>
+          <li><strong>Polyvalence</strong>&nbsp;: exécution immédiate via VM, compilation native, intégration en C.</li>
+          <li><strong>Sécurité</strong>&nbsp;: gestion mémoire déterministe (références comptées), erreurs explicites (<code>Result</code>, <code>panic</code>).</li>
+          <li><strong>Portabilité</strong>&nbsp;: fonctionne sur Linux, BSD, macOS, Windows.</li>
+        </ul>
+      </section>
 
+      <section id="pour-qui">
+        <h3>0.2 Pour qui est fait VITL&nbsp;?</h3>
+        <p><strong>Débutant</strong></p>
+        <ul>
+          <li>Découvrir la programmation avec une syntaxe simple et lisible.</li>
+          <li>Éviter la complexité (pointeurs, mémoire manuelle, GC lourd).</li>
+          <li>Apprendre progressivement&nbsp;: immutabilité, <code>Result</code>, <code>match</code>.</li>
+        </ul>
+        <p><strong>Développeur intermédiaire</strong></p>
+        <ul>
+          <li>Scripts rapides et compacts pour automatiser des tâches.</li>
+          <li>Petites applications CLI portables.</li>
+          <li>Formateur, linter et tests intégrés.</li>
+        </ul>
+        <p><strong>Professionnel</strong></p>
+        <ul>
+          <li>Compilation native optimisée (<code>-O3</code>).</li>
+          <li>FFI C stable pour réutiliser des bibliothèques existantes.</li>
+          <li>Intégration CI/CD, packaging, inspection IR/bytecode (<code>--emit-ir</code>, <code>--emit-bytecode</code>).</li>
+        </ul>
+      </section>
 
+      <section id="domaines">
+        <h3>0.3 Domaines d'utilisation</h3>
+        <ol>
+          <li><strong>Écriture rapide de scripts CLI</strong> : remplacement ciblé de Bash/Python, automatisation, parsing, texte.</li>
+          <li><strong>Compilation en exécutables natifs</strong> : binaires autonomes, distribution, embarqué, multi-plateformes.</li>
+          <li><strong>Langage embarqué (FFI C)</strong> : intégration dans des projets C, chargement de <code>.vitbc</code>, scripts extensibles.</li>
+        </ol>
+      </section>
 
-──────────────────────────────────────────────
+      <section id="points-forts">
+        <h3>0.4 Points forts</h3>
+        <ul>
+          <li>Syntaxe lisible et unifiée (identique à Vitte).</li>
+          <li>Gestion mémoire <code>Rc</code>/<code>Weak</code> simple et prévisible.</li>
+          <li>Erreurs explicites <code>Result</code> et propagation <code>?</code>.</li>
+          <li>Stdlib couvrant I/O, fichiers, chaînes, maths, temps, vecteurs.</li>
+          <li>Outils intégrés : <code>fmt</code>, <code>check</code>, <code>test</code>, <code>doc</code>.</li>
+          <li>Exécution directe ou compilation native optimisée.</li>
+          <li>FFI C stable et facile.</li>
+        </ul>
+      </section>
 
-1) STRUCTURE DE PROJET — GUIDE COMPLET
-──────────────────────────────────────
-Un projet VITL repose sur une organisation stricte des dossiers et fichiers.
-Cette rigueur facilite la navigation, la compilation et l’intégration dans des 
-outils externes (CMake, Meson, CI/CD, IDE).
+      <section id="hello">
+        <h3>0.5 Exemple rapide (Hello World)</h3>
+<pre><code>module app.main
+import std.io
 
-──────────────────────────────────────
-1.1 Arborescence type minimale
-──────────────────────────────────────
-/src      → code source principal (.vitl)
-/libs     → bibliothèques natives C/FI (.c, .so, .dll, .a)
-/build    → binaires compilés, artefacts intermédiaires, bytecode (.vitbc)
+fn main() -&gt; i32 {
+  std.io::println("Bonjour Vitte Light")
+  return 0
+}
+</code></pre>
+        <p><strong>Exécution</strong> : <code>vitl run src/main.vitl</code></p>
+        <p><strong>Compilation</strong> : <code>vitl build -O2 -o build/app src/main.vitl &amp;&amp; ./build/app</code></p>
+        <p class="note"><strong>Résumé</strong> — Débutant : apprendre sans complexité inutile · Intermédiaire : scripts compacts et portables · Pro : compilateur performant, FFI C stable, toolchain complète.</p>
+      </section>
+    </section>
 
-Exemple :
-  mon_projet/
-    src/
-      main.vitl
-      util/str.vitl
-    libs/
-      mylib.c
-      mylib.a
-    build/
-      app            (binaire natif)
-      app.vitbc      (bytecode compilé)
+    <hr />
 
-──────────────────────────────────────
-1.2 Convention des modules
-──────────────────────────────────────
-— Un fichier correspond à un module unique.
-— Le chemin disque reflète le nom du module.
-— Le nom de module s’écrit en `snake.case`.
+    <!-- 1) STRUCTURE -->
+    <section id="structure">
+      <h2>1) Structure de projet — Guide complet</h2>
+      <p>Un projet VITL repose sur une organisation stricte des dossiers et fichiers pour faciliter navigation, compilation et intégration (CMake, Meson, CI/CD, IDE).</p>
 
-Exemple :
-  Fichier : src/std/io.vitl
-  Contenu : module std.io
+      <h3>1.1 Arborescence type minimale</h3>
+<pre><code>/src   → code source principal (.vitl)
+ /libs → bibliothèques natives C/FFI (.c, .so, .dll, .a)
+ /build→ binaires, artefacts intermédiaires, bytecode (.vitbc)
 
-Règle : **hiérarchie dossier = hiérarchie de module**.
+mon_projet/
+  src/
+    main.vitl
+    util/str.vitl
+  libs/
+    mylib.c
+    mylib.a
+  build/
+    app        (binaire natif)
+    app.vitbc  (bytecode)
+</code></pre>
 
-Bénéfices :
-— Import clair et intuitif :
-     import std.io
-     import util.str
-— Évite les conflits de noms.
-— Favorise la réutilisation de modules indépendants.
+      <h3>1.2 Convention des modules</h3>
+      <ul>
+        <li>Un fichier = un module.</li>
+        <li>Chemin disque = nom de module.</li>
+        <li>Nom en <code>snake.case</code>.</li>
+      </ul>
+<pre><code>Fichier : src/std/io.vitl
+Contenu : module std.io
+</code></pre>
+      <p>Imports clairs : <code>import std.io</code>, <code>import util.str</code>. Évite les conflits, favorise la réutilisation.</p>
 
-──────────────────────────────────────
-1.3 Organisation recommandée
-──────────────────────────────────────
-Niveaux typiques d’un projet :
-
-/src
-  app/              → logique applicative (main, modules spécifiques)
-  std/              → standard library locale/complémentaire
-  util/             → utilitaires internes (par ex. parsing, formatage)
-
+      <h3>1.3 Organisation recommandée</h3>
+<pre><code>/src
+  app/  → logique applicative
+  std/  → std locale/complémentaire
+  util/ → utilitaires internes
 /libs
-  externe/          → wrappers C tiers (sqlite.c, ssl.c…)
-  interne/          → code C maison à exposer via FFI
-
+  externe/ → wrappers C tiers
+  interne/ → code C maison via FFI
 /build
-  debug/            → builds avec -O0 -g
-  release/          → builds optimisés avec -O3
-  docs/             → documentation générée par `vitl doc`
-
-──────────────────────────────────────
-1.4 Raison d’être de la rigueur
-──────────────────────────────────────
-Débutant
-— Vous savez toujours où chercher vos fichiers.
-— Le projet reste simple à lire, même avec plusieurs sources.
-
-Intermédiaire
-— Séparation claire entre code applicatif et librairies natives.
-— Possibilité de réutiliser un module sans embarquer tout le projet.
-— Tests plus faciles : `vitl test` explore /src et repère vos fichiers.
-
-Pro
-— Packaging plus simple (chaque dossier a un rôle précis).
-— CI/CD : scripts de build ciblent `/src` et exportent dans `/build`.
-— Compatibilité naturelle avec outils externes (CMake, Meson, Ninja).
-— FFI C propre : tout ce qui est natif est dans `/libs`, sans polluer `/src`.
-
-──────────────────────────────────────
-1.5 Variantes de structure
-──────────────────────────────────────
-Projet simple (script unique)
-  /src/main.vitl
-
-Projet moyen (appli CLI avec libs perso)
-  /src/
-    main.vitl
-    cli/args.vitl
-    math/geom.vitl
-  /libs/
-    fastmath.c
-  /build/
-
-Projet complexe (grosse appli avec tests et doc)
-/src/
-  app/
-    main.vitl
-    net/http.vitl
-    net/tcp.vitl
-  core/
-    error.vitl
-    config.vitl
-/tests/
-  test_math.vitl
-  test_net.vitl
-/libs/
-  sqlite/
-    sqlite3.c
-/build/
-  debug/
-  release/
-  docs/
-
-──────────────────────────────────────
-1.6 Conseils pratiques
-──────────────────────────────────────
-— Toujours commencer un fichier source par :
-     module chemin.nom
-— Grouper les imports immédiatement après.
-— Garder /src pour le code VITL, /libs pour le C natif, /build pour les binaires.
-— Ajouter /tests si le projet grandit, et y placer uniquement des modules de tests.
-— Ne jamais mélanger artefacts compilés et sources dans le même dossier.
-
-──────────────────────────────────────
-Résumé
-✓ /src : code VITL (modules).  
-✓ /libs : code natif pour FFI.  
-✓ /build : binaires et docs.  
-✓ Nom module = chemin fichier.  
-✓ Structure stricte = lisibilité, maintenabilité, intégration CI/CD.
-
-
-──────────────────────────────────────────────
-2) OUTILS EN LIGNE DE COMMANDE — GUIDE COMPLET
-──────────────────────────────────────────────
-Vitte Light (VITL) propose un environnement de compilation et d’exécution 
-via une CLI (Command Line Interface). Selon la distribution, tu peux avoir :
-
-— Un binaire unique `vitl`
-   → combine compilation, VM, outils (fmt, check, test, doc).
-— Un couple `vitlc` (compilateur) et `vitlv` (machine virtuelle)
-   → approche plus modulaire, utile si tu veux séparer build et exécution.
-
-──────────────────────────────────────────────
-2.1 Exécution immédiate (VM/JIT)
-──────────────────────────────────────────────
-Commande :
-  vitl run src/main.vitl
-ou :
-  vitlv run src/main.vitl
-
-Explications :
-— Le code source est lu, compilé en bytecode, puis exécuté directement par la VM.
-— Idéal pour tester rapidement un script sans passer par la compilation native.
-— La VM vérifie aussi certains invariants (sécurité mémoire, erreurs de syntaxe).
-
-Cas d’usage :
-— Débutant : écrire un petit script et voir le résultat instantanément.
-— Intermédiaire : prototypage rapide avant intégration.
-— Pro : usage pour tests automatisés dans CI/CD (exécution sans build).
-
-Erreur fréquente :
-— Oublier le chemin du fichier → `vitl run` sans argument affiche l’aide.
-
-──────────────────────────────────────────────
-2.2 Compilation en exécutable natif
-──────────────────────────────────────────────
-Commande :
-  vitl build -O2 -o build/app src/main.vitl
-ou :
-  vitlc -O2 -o build/app src/main.vitl
-
-Explications :
-— Génère un binaire exécutable natif (Linux, BSD, macOS, Windows selon cible).
-— -O2 active des optimisations standards (taille/rapidité équilibrée).
-— Le résultat se trouve dans `/build` par convention.
-
-Avantages :
-— Démarrage instantané (pas besoin de VM).
-— Binaire autonome, facile à distribuer.
-— Plus de performance pour des calculs lourds.
-
-Cas d’usage :
-— Intermédiaire : distribuer un outil CLI interne.
-— Pro : créer un exécutable pour production, packagé avec CI/CD.
-
-──────────────────────────────────────────────
-2.3 Outils supplémentaires
-──────────────────────────────────────────────
-**Formateur automatique**  
-  vitl fmt src/  
-— Réorganise imports, corrige indentation, uniformise accolades.  
-— Conseillé pour tous : garde un style homogène entre équipes.
-
-**Analyse statique**  
-  vitl check src/  
-— Détecte variables inutilisées, branches mortes, conversions implicites.  
-— Intermédiaire/Pro : indispensable avant commit ou merge.
-
-**Tests unitaires**  
-  vitl test  
-— Exécute tous les blocs `test "nom" { ... }` définis dans le code.  
-— Débutant : apprendre à valider ses fonctions.  
-— Pro : automatiser la validation dans pipelines CI.
-
-**Documentation automatique**  
-  vitl doc src/ -o build/docs.txt  
-— Extrait les commentaires `///` en documentation utilisateur.  
-— Pro : permet de livrer une doc synchronisée avec le code.
-
-──────────────────────────────────────────────
-2.4 Options utiles
-──────────────────────────────────────────────
-— `-O0` : pas d’optimisation, build rapide pour debug.  
-— `-O1` : optimisation légère.  
-— `-O2` : compromis vitesse/taille (valeur par défaut).  
-— `-O3` : optimisations agressives (inlining, unroll).  
-— `-g`  : inclut symboles de debug, nécessaire pour `std.debug::backtrace`.  
-
-Exemple debug :
-  vitl build -O0 -g -o build/app src/main.vitl
-  ./build/app
-
-— `--emit-ir` : imprime l’IR (Intermediate Representation) lisible par humain.  
-— `--emit-bytecode` : génère un fichier `.vitbc` (format binaire standardisé).  
-
-Cas d’usage :
-— Étudiant/chercheur : `--emit-ir` pour étudier la compilation.  
-— Pro : `--emit-bytecode` pour intégrer VITBC dans un pipeline VM.
-
-──────────────────────────────────────────────
-2.5 Bonnes pratiques CLI
-──────────────────────────────────────────────
-Débutant :
-— Utiliser `vitl run` pour tester rapidement.
-— Ajouter `vitl fmt` pour s’habituer au style standard.
-
-Intermédiaire :
-— Compiler avec `vitl build -O2 -g` pour avoir à la fois optimisation et debug.
-— Vérifier le code avec `vitl check` avant tout commit.
-
-Pro :
-— Intégrer `vitl test` et `vitl check` dans une pipeline CI/CD.
-— Distribuer des exécutables compilés avec `-O3` pour prod.
-— Générer docs avec `vitl doc` pour livrer aux utilisateurs.
-
-──────────────────────────────────────────────
-2.6 Erreurs fréquentes
-──────────────────────────────────────────────
-— E0001 : fichier introuvable → chemin incorrect dans la commande.
-— Permission denied → oublier `chmod +x` sur un binaire généré.
-— Mauvais ordre d’options → `-o build/app` doit suivre la commande `build`.
-
-──────────────────────────────────────────────
-Résumé
-— `vitl run` : exécution directe dans la VM.  
-— `vitl build` : compilation en exécutable natif.  
-— `vitl fmt`, `vitl check`, `vitl test`, `vitl doc` : outillage quotidien.  
-— Options -O et -g : choisir entre debug et performance.  
-— Outils pensés pour couvrir du **prototype rapide** jusqu’au **binaire distribué**.
-
-
-
-──────────────────────────────────────────────
-
-3) SYNTAXE : DÉCOUVERTE PROGRESSIVE
-────────────────────────────────────
-But
-— Apprendre les briques de base de Vitte Light (VITL).
-— Comprendre la logique derrière chaque construction.
-— Éviter les erreurs classiques de syntaxe ou de typage.
-
-────────────────────────────────────
-3.1 Commentaires
-────────────────
-Types de commentaires :
-— Ligne unique : commence par `//`, ignore tout jusqu’à la fin de la ligne.
-— Bloc : délimité par `/* … */`, peut couvrir plusieurs lignes.
-
-Exemple :
-  // ceci est un commentaire simple
-  let x = 42  // vous pouvez aussi commenter après une instruction
-
-  /*
-     commentaire multi-lignes
-     utile pour désactiver temporairement un bloc de code
-  */
-
-Bonne pratique
-— Utiliser `//` pour notes rapides.
-— Utiliser `/* … */` pour documenter un algorithme ou désactiver du code.
-
-────────────────────────────────────
-3.2 Variables et constantes
-───────────────────────────
-Déclaration :
-— `const` : valeur immuable et connue à la compilation.
-— `let`   : variable liée à une valeur. Par défaut immuable.
-— `let mut` : variable mutable.
-
-Exemples :
-  const PI: f64 = 3.14159     // constante avec type explicite
-  let mut compteur: i32 = 0   // variable modifiable
-  let message = "Salut"       // type inféré automatiquement = str
-
-Inférence de type
-— Le compilateur déduit le type si ce n’est pas ambigu.
-— Pour une API publique, toujours annoter le type explicitement.
-
-Erreur fréquente
-— Oublier `mut` :
-    let n = 0
-    n = n + 1    // erreur → variable non mutable
-  Correct :
-    let mut n = 0
-    n = n + 1
-
-────────────────────────────────────
-3.3 Fonctions
-────────────────
-Syntaxe :
-  fn nom(param: Type, ...) -> TypeRetour {
-    // corps
-    return valeur
-  }
-
-Exemple :
-  fn add(a: i32, b: i32) -> i32 {
-    return a + b
-  }
-
-Notes
-— Le mot-clé `fn` introduit une fonction.
-— Paramètres typés explicitement.
-— Le `return` indique la valeur renvoyée.
-— Si la fonction ne renvoie rien : `-> ()`.
-
-Variante courte
-  fn square(x: i32) -> i32 { return x*x }
-
-Erreur fréquente
-— Oublier `-> TypeRetour` :
-    fn bad(x: i32) { return x*x }   // erreur : manque le type
-
-────────────────────────────────────
-3.4 Structures de contrôle
-──────────────────────────
-Conditionnelle `if`
-  if x > 0 {
-    println("positif")
-  } else {
-    println("non positif")
-  }
-
-Boucle `for`
-— Itère sur un intervalle ou une collection.
-— Intervalle exclusif `0..10` → 0 à 9.
-— Intervalle inclusif `0..=10` → 0 à 10.
-
-Exemple :
-  for i in 0..10 {
-    println(i.to_string())
-  }
-
-Boucle `while`
-  let mut n = 0
-  while n < 5 {
-    println(n.to_string())
-    n = n + 1
-  }
-
-Erreur fréquente
-— Boucle infinie non voulue (oublier d’incrémenter un compteur).
-
-────────────────────────────────────
-3.5 Match (pattern matching puissant)
-────────────────────────────────────
-`match` compare une valeur à différents motifs.
-
-Exemple simple :
-  match valeur {
-    0 => println("zéro"),
-    1 | 2 => println("petit"),   // alternative avec |
-    _ => println("autre")        // _ = cas par défaut
-  }
-
-Exemple avec enum :
-  enum Status { Ok, Err(str) }
-
-  let s = Status::Err("oops")
-
-  match s {
-    Status::Ok => println("ok"),
-    Status::Err(msg) => println("erreur: " + msg),
-  }
-
-Avantages
-— Plus expressif que des if/else imbriqués.
-— Forçage à couvrir tous les cas (sauf si `_` utilisé).
-
-Erreur fréquente
-— Oublier un cas dans un `match` exhaustif :
-    enum Color { Red, Green, Blue }
-    match c {
-      Color::Red => println("rouge"),
-      Color::Green => println("vert")
-    }
-  → erreur : cas `Blue` manquant
-
-────────────────────────────────────
-3.6 Types de base et littéraux
-──────────────────────────────
-Entiers :
-— Décimaux : 0, 42, 1_000
-— Hexa : 0xFF
-— Octal : 0o755
-— Binaire : 0b1010
-
-Flottants :
-— 3.14, 2.0e-3
-
-Booléens :
-— true, false
-
-Caractères :
-— 'a', '\n'
-
-Chaînes :
-— "texte normal"
-— r"brut sans échappement"
-
-────────────────────────────────────
-3.7 Bonnes pratiques de style
-─────────────────────────────
-Débutant
-— Déclarer vos variables avec `let` et types simples.
-— Utiliser `println` pour vérifier les valeurs.
-
-Intermédiaire
-— Isoler les tests dans des fonctions et utiliser `assert`.
-— Toujours traiter tous les cas d’un `match`.
-
-Pro
-— Factoriser vos contrôles avec `match` au lieu d’empiler des `if`.
-— Éviter les conversions implicites ; soyez explicite avec `as`.
-
-────────────────────────────────────
-Résumé
-— Commentaires : `//` ou `/* … */`.
-— Variables : immuables par défaut, `mut` si nécessaire.
-— Fonctions : `fn nom(param: Type) -> Type`.
-— Contrôle : `if`, `while`, `for`.
-— Pattern matching : `match`, exhaustif et clair.
-
-
-──────────────────────────────────────────────
-
-4) PREMIERS EXEMPLES — DÉTAILLÉS
-────────────────────────────────
-Objectif
-— T’aider à écrire, exécuter, compiler et tester trois programmes “types”.
-— Montrer les erreurs fréquentes et leurs corrections.
-— Donner des variantes utiles pour aller un cran plus loin.
-
-Pré-requis
-— Arbo conseillée :
-    /src
-      main.vitl        (exemple débutant)
-      cat.vitl         (exemple intermédiaire)
-      geom.vitl        (exemple pro)
-— Exécution VM :
-    vitl run src/main.vitl
-— Compilation native :
-    vitl build -O2 -o build/app src/main.vitl
-
-
-4.1 Débutant → programme minimal
-────────────────────────────────
-But
-— Afficher du texte. Vérifier que la toolchain fonctionne.
-
-Code (src/main.vitl)
-  module app.main
-  import std.io
-
-  fn main() -> i32 {
-    std.io::println("Bonjour Vitte Light")
-    return 0
-  }
-
-Explications
-— `module app.main` : identifie le module du fichier.
-— `import std.io` : active les fonctions d’E/S console.
-— `main() -> i32` : point d’entrée, retourne un code de sortie.
-— `println(...)` : écrit sur stdout puis ajoute un saut de ligne.
-
-Exécution (VM)
-  vitl run src/main.vitl
-
-Compilation (binaire)
-  vitl build -O2 -o build/hello src/main.vitl
-  ./build/hello
-
-Sortie attendue
-  Bonjour Vitte Light
-
-Erreurs fréquentes
-— E0001 symbole inconnu : oublier `import std.io`.
-— E0002 types incompatibles : concaténer nombre + string sans `.to_string()`.
-
-Variante A — afficher une variable
-  fn main() -> i32 {
-    let n = 42
-    std.io::println("n=" + n.to_string())
-    return 0
-  }
-
-Variante B — codes d’erreur
-  fn main() -> i32 {
-    if 2 + 2 != 4 {
-      std.io::eprintln("arithmétique cassée")
-      return 1  // code d’erreur générique
-    }
-    return 0
-  }
-
-
-4.2 Intermédiaire → lire un fichier
-───────────────────────────────────
-But
-— Lire un fichier texte passé en argument. Gérer les erreurs proprement.
-
-Code (src/cat.vitl)
-  module app.cat
-  import std.{fs, io, cli, str}
-
-  fn main() -> i32 {
-    let argv = cli::args()
-    if str::len(argv) < 2 {
-      io::eprintln("usage: cat <fichier>")
-      return 2  // convention: 2 = erreur d’usage
-    }
-    let path = argv[1]
-    if !fs::exists(path) {
-      io::eprintln("introuvable: " + path)
-      return 3  // convention: 3 = I/O
-    }
-    let contenu = fs::read_to_string(path)?   // propage l’erreur I/O
-    io::print(contenu)
-    return 0
-  }
-
-Explications
-— `cli::args()` : récupère les arguments CLI sous forme de [String].
-— `str::len(argv)` : taille. On exige au moins 2 éléments (binaire + fichier).
-— `fs::exists(path)` : évite une erreur inutile avant lecture.
-— `read_to_string(path)?` : renvoie Result<String, Error>. `?` propage l’erreur au runtime sous forme d’un code ≠ 0.
-— `return 2/3` : codes de sortie standardisés.
-
-Exécution
-  vitl run src/cat.vitl -- data.txt
-
-Sorties possibles
-— OK : affiche le contenu du fichier.
-— Erreur d’usage : `usage: cat <fichier>` avec code 2.
-— Fichier manquant : `introuvable: ...` avec code 3.
-
-Erreurs fréquentes
-— E2001 fichier non trouvé : oublier le test `exists`.
-— E0002 concat de String + i32 sans `.to_string()`.
-
-Variante A — lecture binaire
-  // Pour fichiers non-UTF8
-  let bytes = fs::read(path)?        // [u8]
-  io::println("taille=" + bytes.len().to_string())
-
-Variante B — chronométrer l’opération
-  let t0 = std.time::now()
-  let contenu = fs::read_to_string(path)?
-  io::println("ms=" + (std.time::now() - t0).to_string())
-
-Variante C — “cat” multi-fichiers avec boucle
-  for i in 1..str::len(argv) {
-    let p = argv[i]
-    if !fs::exists(p) { io::eprintln("skip: " + p); continue }
-    io::print(fs::read_to_string(p)?)
-  }
-
-
-4.3 Pro → struct, impl, méthodes
-────────────────────────────────
-But
-— Définir un type, ajouter des méthodes, calculer une norme, tester.
-
-Code (src/geom.vitl)
-  module app.geom
-  import std.{io, math}
-
-  struct Vec2 { x: f64, y: f64 }
-
-  impl Vec2 {
-    fn norm(&self) -> f64 {
-      return (self.x*self.x + self.y*self.y).sqrt()
-    }
-    fn dot(&self, o: Vec2) -> f64 {
-      return self.x*o.x + self.y*o.y
-    }
-  }
-
-  fn main() -> i32 {
-    let v = Vec2 { x: 3.0, y: 4.0 }
-    io::println(v.norm().to_string())  // 5
-    return 0
-  }
-
-Explications
-— `struct Vec2 { x, y }` : type produit par l’utilisateur.
-— `impl Vec2 { … }` : bloc de méthodes associé à Vec2.
-— `&self` : emprunt en lecture, pas de copie complète.
-— `sqrt()` : méthode flt; import indirect via std.math.
-
-Erreurs fréquentes
-— Typo : écrire `self.xself.x` au lieu de `self.x*self.x`.
-— Oublier `import std.math` si l’impl demande des fonctions flottantes.
-
-Tests intégrés
-  test "norm classique 3-4-5" {
-    let v = Vec2 { x:3.0, y:4.0 }
-    assert(v.norm() == 5.0)
-  }
-  test "dot produit orthogonal" {
-    let a = Vec2 { x:1.0, y:0.0 }
-    let b = Vec2 { x:0.0, y:1.0 }
-    assert(a.dot(b) == 0.0)
-  }
-
-Variante A — parsing CLI vers f64
-  import std.{cli, str}
-  fn parse_f64(s: str) -> Result<f64, str> { return str::to_float(s) }
-  fn main() -> i32 {
-    let a = cli::args()
-    if str::len(a) != 3 { io::eprintln("usage: geom <x> <y>"); return 2 }
-    let x = parse_f64(a[1])?    // ? propage une Err("…")
-    let y = parse_f64(a[2])?
-    let v = Vec2 { x:x, y:y }
-    io::println(v.norm().to_string())
-    return 0
-  }
-
-Variante B — mini-bench
-  fn bench(n: i32) -> i32 {
-    let mut acc:f64 = 0.0
-    let base = Vec2 { x:1.234, y:5.678 }
-    for i in 0..n {
-      let v = Vec2 { x: base.x + (i as f64), y: base.y - (i as f64) }
-      acc = acc + v.norm()
-    }
-    // utiliser acc pour éviter l’élimination par l’optimiseur
-    std.io::println("acc=" + acc.to_string())
-    return 0
-  }
-
-  fn main() -> i32 {
-    let t0 = std.time::now()
-    _ = bench(100000)
-    std.io::println("ms=" + (std.time::now()-t0).to_string())
-    return 0
-  }
-
-
-4.4 Bonnes pratiques transverses
-────────────────────────────────
-Style
-— `module` en tête, imports regroupés.
-— snake_case pour fonctions/variables; CamelCase pour types.
-— Types explicites pour API publiques.
-
-Erreurs et robustesse
-— `?` pour propager les erreurs I/O et parsing.
-— Codes de sortie standard : 0 OK, 1 panic, 2 usage, 3 I/O, 4 FFI.
-
-Organisation
-— Un fichier = un module; découper tôt si le fichier grossit.
-— Tests en fin de fichier, liés aux fonctions du module.
-
-Perf
-— Utiliser `std.time::now()` pour mesurer.
-— Éviter les copies inutiles grâce aux slices `[T]`.
-— Pré-allouer avec `std.vec::with_capacity` si la taille est connue.
-
-Sécurité
-— Pas d’`unsafe` dans ces exemples; réserver `unsafe` au FFI.
-— Toujours convertir les chaînes en `CString` avant d’appeler du C.
-
-Raccourcis utiles
-— Formatage auto : `vitl fmt src/`
-— Lint : `vitl check src/`
-— Tests : `vitl test`
-— IR lisible : `vitl build --emit-ir -o /dev/null src/geom.vitl`
-
-
-──────────────────────────────────────────────
-
-5) MÉMOIRE ET SÉCURITÉ — GUIDE DÉTAILLÉ
-────────────────────────────────────────
-Objectif
-— Expliquer comment la mémoire est gérée dans Vitte Light (VITL).
-— Montrer les avantages du modèle choisi et les limites.
-— Donner des stratégies adaptées à chaque niveau d’expérience.
-
-────────────────────────────────────────
-5.1 Modèle mémoire en mode sûr
-──────────────────────────────
-— VITL ne possède pas de garbage collector complexe.
-— La gestion est assurée par **références comptées** (Rc<T>).
-— Quand le compteur de références tombe à zéro, l’objet est libéré immédiatement.
-— Pas de pause GC, pas de collecte asynchrone → comportement prévisible.
-
-Exemple :
-  let a = Rc<int>::new(42)
-  let b = a.clone()        // compteur fort = 2
-  a.drop()                 // compteur fort = 1
-  b.drop()                 // compteur fort = 0 → libération immédiate
-
-Avantages
-— Simplicité : pas de `malloc`/`free` manuel pour l’utilisateur.
-— Déterministe : pas de latence due à un GC qui s’exécute en arrière-plan.
-— Sécurité : la mémoire est libérée dès qu’elle n’est plus accessible.
-
-Limites
-— Les cycles de références (A→B→A) ne sont pas libérés automatiquement.
-— À éviter en structurant vos données avec Rc/Weak.
-
-────────────────────────────────────────
-5.2 Immutabilité et mutabilité
-──────────────────────────────
-— `str` est **immuable** (chaîne littérale ou constante).
-— Pour une chaîne modifiable, utiliser `String` :
-    let mut s = String::from("abc")
-    s.push("d")  // devient "abcd"
-
-— Règle générale :
-  - Immuable par défaut.
-  - Ajouter `mut` uniquement quand nécessaire.
-
-Avantages
-— Facilite le raisonnement : une valeur immuable ne change pas dans une autre partie du code.
-— Réduit les bugs liés aux effets de bord.
-
-────────────────────────────────────────
-5.3 Collections et slices
-────────────────────────
-— Les **slices** `[T]` sont des vues sur un tableau ou un vecteur :
-  Elles permettent de parcourir ou de lire sans recopier les données.
-
-Exemple :
-  let v:[i32] = [1,2,3,4]
-  for x in &v { io::println(x.to_string()) }
-
-— Les vecteurs dynamiques (`std.vec`) allouent sur le tas et grandissent au besoin.
-— Toujours utiliser `vec::with_capacity` si vous connaissez la taille prévue.
-
-────────────────────────────────────────
-5.4 Mode unsafe et pointeurs bruts
-──────────────────────────────────
-— Le mot-clé `unsafe` permet d’utiliser des pointeurs C (*T, *mut T).
-— À réserver aux appels FFI et aux cas bas niveau où Rc ne suffit pas.
-— Dans un bloc unsafe, vous assumez :
-  - Validité du pointeur.
-  - Durée de vie correcte de l’objet.
-  - Alignement mémoire conforme.
-
-Exemple minimal FFI :
-  extern "C" { fn puts(msg:*const char)->i32 }
-  let cstr = std.c::CString::from_str("hi\n")?
-  unsafe { puts(cstr.as_ptr()) }
-
-Bonne pratique
-— Encapsuler les appels `unsafe` dans une fonction VITL sûre, pour isoler le risque.
-
-────────────────────────────────────────
-5.5 Débutant, intermédiaire, pro
-──────────────────────────────────
-Débutant
-— Pas besoin de `free()`, Rc s’occupe de tout.
-— Utilisez `String` si vous devez modifier une chaîne.
-— Évitez tout `unsafe`.
-
-Intermédiaire
-— Apprenez à utiliser Rc/Weak pour éviter les cycles.
-— Utilisez les slices `[T]` pour passer des vues sur des données sans recopier.
-— Familiarisez-vous avec la différence entre `str` et `String`.
-
-Pro
-— Combinez Rc avec des pointeurs faibles (Weak) pour des graphes complexes.
-— Exploitez le FFI en encapsulant soigneusement le code `unsafe`.
-— Si besoin, utilisez des allocateurs personnalisés côté C et liez-les via FFI.
-
-────────────────────────────────────────
-5.6 Erreurs courantes à éviter
-──────────────────────────────
-— Créer des cycles de références Rc → fuite mémoire silencieuse.
-— Passer une String VITL temporaire directement au C → pointeur dangling.
-— Oublier `mut` sur une variable qui doit être modifiée → erreur de compilation.
-— Utiliser `unsafe` sans encapsulation → propagation de bugs difficiles à tracer.
-
-────────────────────────────────────────
-5.7 Récapitulatif
-─────────────────
-✓ Gestion sûre et déterministe via Rc/Weak.  
-✓ Pas de GC, pas de `malloc`/`free` manuel côté VITL.  
-✓ str immuable, String mutable.  
-✓ Slices pour éviter les copies inutiles.  
-✓ unsafe réservé aux experts pour FFI/pointeurs.  
-
-
-──────────────────────────────────────────────
-
-6) GESTION DES ERREURS
-──────────────────────
-Type standard : `Result<T, E>`  
-- `Ok(T)` → succès avec valeur
-- `Err(E)` → erreur avec info
-
-Propagation automatique avec `?` :
-let contenu = fs::read_to_string("config.txt")?
-
-yaml
-Copier le code
-
-Gestion explicite :
-match fs::read_to_string("config.txt") {
-Result::Ok(txt) => println(txt),
-Result::Err(e) => eprintln(e)
+  debug/   → -O0 -g
+  release/ → -O3
+  docs/    → `vitl doc`
+</code></pre>
+
+      <h3>1.4 Raison d’être</h3>
+      <p>Débutant&nbsp;: lisibilité · Intermédiaire&nbsp;: séparation claire, tests faciles · Pro&nbsp;: packaging, CI/CD, FFI propre.</p>
+
+      <h3>1.5 Variantes de structure</h3>
+<pre><code>Projet simple : /src/main.vitl
+
+Projet moyen :
+  /src main.vitl  cli/args.vitl  math/geom.vitl
+  /libs fastmath.c
+
+Projet complexe :
+  /src app/main.vitl  net/http.vitl  net/tcp.vitl  core/error.vitl  config.vitl
+  /tests test_math.vitl  test_net.vitl
+  /libs/sqlite/sqlite3.c
+  /build/{debug,release}
+  /docs
+</code></pre>
+
+      <h3>1.6 Conseils pratiques</h3>
+      <ul>
+        <li><code>module chemin.nom</code> en tête de fichier, puis les <code>import</code>.</li>
+        <li><code>/src</code> pour VITL, <code>/libs</code> pour C, <code>/build</code> pour binaires.</li>
+        <li><code>/tests</code> dédié si le projet grandit.</li>
+        <li>Ne pas mélanger artefacts et sources.</li>
+      </ul>
+
+      <p class="card"><strong>Résumé</strong> — <code>/src</code> : VITL · <code>/libs</code> : FFI · <code>/build</code> : binaires/docs · Nom module = chemin · Rigueur = lisibilité/CI.</p>
+    </section>
+
+    <hr />
+
+    <!-- 2) CLI -->
+    <section id="cli">
+      <h2>2) Outils en ligne de commande — Guide complet</h2>
+      <p>Selon la distribution :</p>
+      <ul>
+        <li><strong>Binaire unique</strong> <code>vitl</code> (compilation, VM, <code>fmt</code>, <code>check</code>, <code>test</code>, <code>doc</code>).</li>
+        <li><strong>Couple</strong> <code>vitlc</code> (compilateur) + <code>vitlv</code> (VM) pour séparer build/exécution.</li>
+      </ul>
+
+      <h3>2.1 Exécution immédiate (VM/JIT)</h3>
+<pre><code>vitl run src/main.vitl
+# ou
+vitlv run src/main.vitl
+</code></pre>
+      <ul>
+        <li>Compile en bytecode puis exécute dans la VM (vérifs sécurité/syntaxe).</li>
+        <li>Idéal pour tester vite, prototyper, CI sans build.</li>
+        <li>Erreur fréquente : oublier le chemin (affiche l’aide).</li>
+      </ul>
+
+      <h3>2.2 Compilation en exécutable natif</h3>
+<pre><code>vitl build -O2 -o build/app src/main.vitl
+# ou
+vitlc -O2 -o build/app src/main.vitl
+</code></pre>
+      <ul>
+        <li>Binaire natif, autonome, rapide.</li>
+      </ul>
+
+      <h3>2.3 Outils supplémentaires</h3>
+<pre><code>vitl fmt src/             # formateur
+vitl check src/           # analyse statique
+vitl test                 # exécute les blocs `test "nom" { ... }`
+vitl doc src/ -o build/docs.txt  # documentation à partir de ///</code></pre>
+
+      <h3>2.4 Options utiles</h3>
+      <ul>
+        <li><code>-O0</code>, <code>-O1</code>, <code>-O2</code> (défaut), <code>-O3</code></li>
+        <li><code>-g</code> pour debug/backtrace</li>
+        <li><code>--emit-ir</code>, <code>--emit-bytecode</code></li>
+      </ul>
+<pre><code>vitl build -O0 -g -o build/app src/main.vitl &amp;&amp; ./build/app</code></pre>
+
+      <h3>2.5 Bonnes pratiques CLI</h3>
+      <ul>
+        <li>Débutant : <code>vitl run</code> + <code>vitl fmt</code>.</li>
+        <li>Intermédiaire : <code>vitl build -O2 -g</code> + <code>vitl check</code>.</li>
+        <li>Pro : <code>test</code>/<code>check</code> en CI, livrer <code>-O3</code>, générer la doc.</li>
+      </ul>
+
+      <h3>2.6 Erreurs fréquentes</h3>
+      <ul>
+        <li><strong>E0001</strong> fichier introuvable.</li>
+        <li><strong>Permission denied</strong> : penser à <code>chmod +x</code>.</li>
+        <li>Ordre d’options : <code>-o build/app</code> après <code>build</code>.</li>
+      </ul>
+    </section>
+
+    <hr />
+
+    <!-- 3) SYNTAXE -->
+    <section id="syntaxe">
+      <h2>3) Syntaxe : découverte progressive</h2>
+      <p><strong>But</strong> — Apprendre les briques de base de VITL, comprendre la logique, éviter les erreurs classiques.</p>
+
+      <h3>3.1 Commentaires</h3>
+      <ul>
+        <li>Ligne : <code>//</code> jusqu’à la fin de ligne.</li>
+        <li>Bloc : <code>/* ... */</code> multi-lignes.</li>
+      </ul>
+<pre><code>// commentaire
+let x = 42  // commentaire en fin de ligne
+
+/* commentaire multi-lignes */
+</code></pre>
+
+      <h3>3.2 Variables et constantes</h3>
+<pre><code>const PI: f64 = 3.14159
+let mut compteur: i32 = 0
+let message = "Salut"  // inférence: str
+
+// Erreur : variable non mutable
+let n = 0
+n = n + 1
+
+// Correct
+let mut n = 0
+n = n + 1
+</code></pre>
+
+      <h3>3.3 Fonctions</h3>
+<pre><code>fn add(a: i32, b: i32) -&gt; i32 { return a + b }
+
+// variante
+fn square(x: i32) -&gt; i32 { return x * x }
+
+// Erreur : manque le type de retour
+fn bad(x: i32) { return x * x }
+</code></pre>
+
+      <h3>3.4 Structures de contrôle</h3>
+<pre><code>if x &gt; 0 { println("positif") } else { println("non positif") }
+
+for i in 0..10 { println(i.to_string()) }  // 0..9
+for i in 0..=10 { println(i.to_string()) } // 0..10
+
+let mut n = 0
+while n &lt; 5 { println(n.to_string()); n = n + 1 }
+</code></pre>
+
+      <h3>3.5 <code>match</code> (pattern matching)</h3>
+<pre><code>match valeur {
+  0 =&gt; println("zéro"),
+  1 | 2 =&gt; println("petit"),
+  _ =&gt; println("autre"),
 }
 
-scss
-Copier le code
+enum Status { Ok, Err(str) }
+let s = Status::Err("oops")
+match s {
+  Status::Ok =&gt; println("ok"),
+  Status::Err(msg) =&gt; println("erreur:" + msg),
+}
+</code></pre>
 
-`panic("msg")` → erreur irrécupérable, arrêt du programme.
+      <h3>3.6 Types de base et littéraux</h3>
+      <ul>
+        <li>Entiers : <code>0</code>, <code>42</code>, <code>1_000</code>, <code>0xFF</code>, <code>0o755</code>, <code>0b1010</code></li>
+        <li>Flottants : <code>3.14</code>, <code>2.0e-3</code></li>
+        <li>Booléens : <code>true</code>, <code>false</code></li>
+        <li>Caractères : <code>'a'</code>, <code>'\n'</code></li>
+        <li>Chaînes : <code>"..."</code>, <code>r"..."</code></li>
+      </ul>
 
-──────────────────────────────────────────────
+      <h3>3.7 Bonnes pratiques de style</h3>
+      <p>Débutant : <code>let</code> + <code>println</code> · Intermédiaire : <code>assert</code>, <code>match</code> exhaustif · Pro : conversions explicites avec <code>as</code>.</p>
 
-7) INTEROPÉRABILITÉ C (FFI) — GUIDE AVANCÉ
-───────────────────────────────────────────
-But
-— Appeler du code C depuis Vitte Light (VITL) en sécurité.
-— Définir un « shim C » propre et portable.
-— Gérer chaînes, buffers, erreurs, et l’édition de liens.
+      <p class="card"><strong>Résumé</strong> — Commentaires <code>//</code>/<code>/*...*/</code> · variables immuables par défaut (<code>mut</code> si besoin) · fonctions <code>fn</code> · contrôles <code>if</code>/<code>while</code>/<code>for</code> · <code>match</code> exhaustif.</p>
+    </section>
 
-Principes
-— ABI supportée : C uniquement.
-— Toute interaction mémoire non vérifiée est `unsafe`.
-— Réduire la surface `unsafe` au strict minimum.
-— Toujours documenter qui alloue et qui libère.
+    <hr />
 
-7.1 Déclaration et appel minimal
-────────────────────────────────
-Déclarer une fonction C exposée :
-  extern "C" { fn puts(msg: *const char) -> i32 }
+    <!-- 4) EXEMPLES -->
+    <section id="exemples">
+      <h2>4) Premiers exemples — détaillés</h2>
+      <p><strong>Objectif</strong> — Écrire, exécuter, compiler et tester trois programmes types, avec erreurs fréquentes et variantes.</p>
+      <p><strong>Pré-requis</strong> — Arbo conseillée : <code>/src</code> avec <code>main.vitl</code>, <code>cat.vitl</code>, <code>geom.vitl</code>.</p>
 
-Construire une CString et appeler :
-  let cstr = std.c::CString::from_str("Hello C!\n")?
-  unsafe { _ = puts(cstr.as_ptr()) }
+      <h3>4.1 Débutant → programme minimal</h3>
+<pre><code>// src/main.vitl
+module app.main
+import std.io
 
-Lien à la lib C standard (exemple) :
-  vitl build -O2 -L libs -lc -o build/app src/main.vitl
+fn main() -&gt; i32 {
+  std.io::println("Bonjour Vitte Light")
+  return 0
+}
+</code></pre>
+<pre><code># Exécution (VM)
+vitl run src/main.vitl
 
-Notes
-— `CString::from_str` échoue si le texte contient un octet nul `\0`.
-— `puts` attend une chaîne C null-terminée. Ne jamais passer `str` brut.
+# Compilation (binaire)
+vitl build -O2 -o build/hello src/main.vitl
+./build/hello
 
-7.2 Chaînes et ownership
-────────────────────────
-Entrée VITL → C :
-— Convertir avec `CString::from_str`.
-— Conserver la CString vivante pendant tout l’appel C (durée de vie).
+# Sortie attendue
+Bonjour Vitte Light
+</code></pre>
+      <ul>
+        <li>E0001 symbole inconnu : oublier <code>import std.io</code>.</li>
+        <li>E0002 types incompatibles : concaténer nombre + string sans <code>.to_string()</code>.</li>
+      </ul>
+<pre><code>// Variante A
+fn main() -&gt; i32 {
+  let n = 42
+  std.io::println("n=" + n.to_string())
+  return 0
+}
 
-Retour C → VITL :
-— Si la lib C **renvoie** `const char*` pointant sur un buffer interne,
-  copier immédiatement côté VITL et **ne pas** libérer côté VITL.
-— Si la lib C **alloue** et te transfère la propriété (ex: `char*` via malloc),
-  convertir en String puis libérer via `c::free(ptr)` si c’est ton contrat.
-
-Pattern de contrat (recommandé) côté C :
-— Fournir des paires `create/destroy`, `dup/free`, et préciser l’allocateur.
-
-7.3 Buffers binaires et slices
-──────────────────────────────
-Passage d’un slice VITL `[u8]` vers C :
-— Passer `ptr` et `len` séparément :
-    extern "C" { fn sha256(data:*const u8, len:usize, out:*mut u8) -> i32 }
-— Créer un buffer de sortie côté VITL et passer `as_mut_ptr()` :
-    let mut out:[u8] = [0; 32]
-    unsafe { _ = sha256(input.as_ptr(), input.len(), out.as_mut_ptr()) }
-
-Règles
-— Toujours passer `len`. Ne jamais supposer qu’un buffer est null-terminé.
-— Vérifier les bornes côté VITL avant l’appel. Ne jamais dépasser `out` cap.
-
-7.4 Structs : opacité plutôt que couplage
-───────────────────────────────────────────
-Éviter d’échanger des `struct` C inline (alignement/ABI cross-platform).
-Préférer un **handle opaque** :
-
-C (shim) :
-  typedef struct Obj Obj;
-  Obj* obj_create(int cap);
-  void obj_destroy(Obj*);
-  int  obj_push(Obj*, const char* s);   // 0 ok, <0 err
-  int  obj_len(const Obj*);
-
-VITL :
-  extern "C" {
-    fn obj_create(cap:i32)->*mut void
-    fn obj_destroy(p:*mut void)->void
-    fn obj_push(p:*mut void, s:*const char)->i32
-    fn obj_len(p:*const void)->i32
+// Variante B (codes d'erreur)
+fn main() -&gt; i32 {
+  if 2 + 2 != 4 {
+    std.io::eprintln("arithmétique cassée")
+    return 1
   }
-  // Convertir str→CString, wrapper en API VITL sûre.
-  // Envelopper les appels dans `unsafe { … }`.
+  return 0
+}
+</code></pre>
 
-7.5 Erreurs et mapping Result
-─────────────────────────────
-Convention côté C :
-— Retour `0` = succès. `<0` = code d’erreur. `>0` = taille/compte utile.
+      <h3>4.2 Intermédiaire → lire un fichier</h3>
+<pre><code>// src/cat.vitl
+module app.cat
+import std.{fs, io, cli, str}
 
-Mapping côté VITL :
-  fn c_call_ok(code:i32) -> Result<(),str> {
-    if code == 0 { return Result::Ok(()) }
-    return Result::Err("ffi: call failed")
-  }
-
-Exemple robuste :
-  let s = std.c::CString::from_str("hi")?
-  let r = unsafe { obj_push(h, s.as_ptr()) }
-  _ = c_call_ok(r)?   // propage l’erreur proprement
-
-Astuce pro
-— Centraliser les conversions (code C → err::Error) dans un module `ffi.err`.
-
-7.6 Callbacks et user_data
-──────────────────────────
-Modèle classique C :
-  typedef void (*cb_t)(const char* msg, void* user);
-  void run_with_cb(cb_t cb, void* user);
-
-VITL :
-  // On ne déclare pas directement des closures VITL vers C.
-  // Pattern : exposer côté C une table de trampolines ou un registre.
-  // C conserve `user` (opaque) et rappelle via cb_t.
-  // VITL fournit un handle `user` obtenu d’un shim C (ex: table indexée).
-
-Recommandation
-— Laisser la gestion des callbacks dans le shim C.
-— VITL envoie un identifiant opaque (`void*`/index) et reçoit des événements
-  retransformés en appels VITL par polling ou par API pull.
-
-7.7 Linking : -L, -l, rpath, static
-────────────────────────────────────
-Dossiers :
-— `-L <dir>` : où chercher les libs.
-— `-lfoo`    : lie `libfoo.so` ou `libfoo.a`.
-
-Exemples
-— Dylib partagée :
-    vitl build -O2 -L libs -lfoo -o build/app src/main.vitl
-— Statique (si dispo) :
-    vitl build -O2 -L libs -Wl,-Bstatic -lfoo -Wl,-Bdynamic -o build/app src/main.vitl
-
-Chargement à l’exécution
-— OpenBSD/Unix : variable d’env `LD_LIBRARY_PATH` ou rpath :
-    vitl build ... -Wl,-rpath,/chemin/vers/libs
-— Windows : `.dll` dans le même dossier que l’exe ou dans le `PATH`.
-
-Bonnes pratiques
-— Versionner `libs/` dans le repo pour reproductibilité (si licences OK).
-— Épingler des versions de libs et documenter le hash/commit.
-
-7.8 Cross-plateforme : tailles et ABI
-─────────────────────────────────────
-— Utiliser des types C stables (`int32_t`, `uint64_t`, `size_t`) côté C.
-— Rester cohérent côté VITL (`i32`, `u64`, `usize`).
-— Éviter les `long`/`unsigned long` (taille change entre plateformes).
-— Attention à l’alignement et à `#pragma pack` → déconseillé.
-
-7.9 Sécurité mémoire : règles d’or
-──────────────────────────────────
-— Aucune écriture hors borne dans des buffers passés à C.
-— Jamais de double free : un seul propriétaire libère.
-— Chaînes : toujours null-terminées côté C.
-— Durée de vie : ne pas garder de pointeur C vers une String VITL temporaire.
-— Sur échec FFI, remettre l’objet VITL dans un état cohérent (ou le détruire).
-
-Checklist rapide
-[ ] Qui alloue ? Qui libère ? Écrit dans la doc.  
-[ ] Les tailles sont passées séparément et validées.  
-[ ] Tous les appels `unsafe` sont encapsulés dans des fonctions sûres.  
-[ ] Codes d’erreur convertis en `Result` avec message contextuel.  
-[ ] Tests d’intégration VITL↔C (succès et erreurs).
-
-7.10 Exemple complet : wrapper « safe » autour d’une lib C
-──────────────────────────────────────────────────────────
-C (shim, libfoo) :
-  typedef struct Foo Foo;
-  Foo* foo_create(int cap);
-  void foo_destroy(Foo*);
-  int  foo_push(Foo*, const char* s);   // 0 ok, -1 err
-  int  foo_len(const Foo*);
-
-VITL (API sûre) :
-  extern "C" {
-    fn foo_create(cap:i32)->*mut void
-    fn foo_destroy(h:*mut void)->void
-    fn foo_push(h:*mut void, s:*const char)->i32
-    fn foo_len(h:*const void)->i32
-  }
-
-  struct Foo { handle:*mut void }
-
-  fn Foo::new(cap:i32) -> Result<Foo,str> {
-    let h = unsafe { foo_create(cap) }
-    if h == std.ptr::null_mut() { return Result::Err("ffi: create failed") }
-    return Result::Ok(Foo{ handle:h })
-  }
-
-  fn Foo::push(&mut self, s:str) -> Result<(),str> {
-    let cstr = std.c::CString::from_str(s)?
-    let rc = unsafe { foo_push(self.handle, cstr.as_ptr()) }
-    if rc != 0 { return Result::Err("ffi: push failed") }
-    return Result::Ok(())
-  }
-
-  fn Foo::len(&self) -> i32 {
-    return unsafe { foo_len(self.handle) }
-  }
-
-  fn Foo::close(&mut self) -> () {
-    if self.handle != std.ptr::null_mut() {
-      unsafe { foo_destroy(self.handle) }
-      self.handle = std.ptr::null_mut()
-    }
-  }
-
-  // Usage :
-  // let mut f = Foo::new(128)?
-  // _ = f.push("abc")?
-  // io::println(f.len().to_string())
-  // f.close()
-
-7.11 Stratégie d’équipe et CI
-─────────────────────────────
-— Figer l’interface C (headers) et ajouter des tests d’intégration.
-— Sur chaque MR/PR, builder le shim C et l’exécutable VITL dans CI.
-— Publier les artefacts : lib partagée + header + empreinte (sha256).
-— Documenter rpath/LD_LIBRARY_PATH et répertoires `libs/`.
-
-7.12 Quand FFI n’est pas le bon outil
-─────────────────────────────────────
-— Appels ultra-fréquents très fins → regroupes-les (batch) côté C.
-— Sérialisation lourde objet par objet → définis un format binaire compact.
-— Besoin de threads natifs → faire tourner un runtime externe via shim.
-
-Résumé
-— L’FFI C de VITL est simple et sûr si le contrat est clair.
-— Opaque handles, CString, ptr+len, Result, surface `unsafe` minimale.
-— Documenter allocation, libération, et versions de libs.
-
-
-──────────────────────────────────────────────
-
-8) STDLIB — APERÇU DÉTAILLÉ
-────────────────────────────
-But
-— Donner une vue opérationnelle des modules standard essentiels.
-— Exposer signatures usuelles, comportements, erreurs courantes.
-— Conseils selon profils: débutant, intermédiaire, pro.
-
-Convention
-— Toutes les fonctions qui touchent au système retournent Result<…>.
-— L’opérateur `?` propage l’erreur vers l’appelant.
-— Les extraits supposent: `import std.{io, fs, str, math, time, cli, vec, debug, err, c}`.
-
-
-8.1 std.io — E/S console
-────────────────────────
-API courante
-— print(x: str|String|affichable)       -> ()
-— println(x: …)                         -> ()
-— eprint(x: …)  (stderr)                -> ()
-— eprintln(x: …) (stderr)               -> ()
-
-Exemples
-  io::println("Hello")
-  io::eprintln("fatal: config manquante")
-
-Bonnes pratiques
-— Préférer `println` pour tracer les étapes clés.
-— Pour concat, convertir: `"n=" + n.to_string()`.
-
-Pièges
-— Trop de logs = bruit. En prod, centraliser les messages d’erreur.
-
-
-8.2 std.fs — Fichiers et chemins
-────────────────────────────────
-API courante
-— read_to_string(path: str)             -> Result<String, err::Error>
-— write_string(path: str, data: str)    -> Result<(), err::Error>
-— read(path: str)                       -> Result<[u8], err::Error>
-— write(path: str, bytes: [u8])         -> Result<(), err::Error>
-— exists(path: str)                     -> bool
-
-Exemples
-  let cfg = fs::read_to_string("config.toml")?
-  _ = fs::write_string("out.txt", "ok\n")?
-
-  if !fs::exists("data.bin") {
-    io::eprintln("absent: data.bin"); return 3
-  }
-
-Débutant
-— Utiliser `read_to_string` pour du texte uniquement.
-Intermédiaire
-— Pour binaire, préférer `read`/`write` en bytes.
-Pro
-— Standardiser des chemins absolus pour la prod; vérifier droits.
-
-Pièges
-— Chemins relatifs dépendants du répertoire courant.
-— Fichiers non UTF-8 → utiliser `read` puis décoder.
-
-
-8.3 std.str — Chaînes et utilitaires
-────────────────────────────────────
-API courante
-— len(s: str|String)                    -> i32
-— split(s: str, sep: char)              -> [String]
-— find(s: str, needle: str)             -> i32    // -1 si absent
-— replace(s: str, from: str, to: str)   -> String
-— to_int(s: str)                        -> Result<i64, str>
-— to_float(s: str)                      -> Result<f64, str>
-
-Exemples
-  let n = str::len("abc")                 // 3
-  let parts = str::split("a b c", ' ')
-  let idx = str::find("abc", "b")         // 1
-  let out = str::replace("a_b", "_", "-") // "a-b"
-  let v = str::to_int("42")?              // i64
-
-Bonnes pratiques
-— Vérifier les Result de parse avec `?` et un message d’erreur clair.
-— Normaliser les entrées (trim, lower/upper) avant comparaison.
-
-Pièges
-— Concat de non-strings sans `.to_string()` → E0002.
-
-
-8.4 std.math — Maths usuelles
-──────────────────────────────
-API courante
-— abs(x: num)                            -> num
-— sqrt(x: f64)                           -> f64
-— sin/cos(x: f64)                        -> f64
-— pow(x: f64, y: f64)                    -> f64
-
-Exemples
-  let d = math::sqrt(3.0*3.0 + 4.0*4.0)  // 5.0
-  let a = math::abs(-12)                 // 12
-
-Bonnes pratiques
-— Rester en `f64` pour stabilité. Convertir les entiers en amont.
-
-Pièges
-— Racine d’un négatif → NaN. Vérifier les bornes avant `sqrt`.
-
-
-8.5 std.time — Horloge et temporisation
-────────────────────────────────────────
-API courante
-— now()                                  -> i64   // ms depuis epoch
-— sleep_ms(ms: i32)                      -> ()
-
-Exemples
-  let t0 = time::now()
-  heavy()
-  io::println((time::now() - t0).to_string() + " ms")
-
-Bonnes pratiques
-— Mesurer les sections critiques pour guider l’optimisation.
-— Pour temporiser une boucle, utiliser `sleep_ms` plutôt qu’un spin.
-
-Pièges
-— Supposer un ordre total strict entre timestamps sur machines variées.
-— Dépendances temporelles dans les tests → stabiliser via fixtures.
-
-
-8.6 std.cli — Arguments et environnement
-────────────────────────────────────────
-API courante
-— args()                                 -> [String]
-— env(key: str)                          -> Option<String>
-— exit(code: i32)                        -> !
-
-Exemples
+fn main() -&gt; i32 {
   let argv = cli::args()
-  if str::len(argv) < 2 { io::eprintln("usage: app <file>"); return 2 }
-  match cli::env("HOME") {
-    Some(h) => io::println(h),
-    None => io::eprintln("HOME non défini")
+  if str::len(argv) &lt; 2 {
+    io::eprintln("usage: cat &lt;fichier&gt;")
+    return 2
   }
-
-Bonnes pratiques
-— Valider tôt les options; retourner 2 en cas d’usage invalide.
-
-Pièges
-— Utiliser `exit` dans des libs. Réserver `exit` au binaire `app.main`.
-
-
-8.7 std.vec — Vecteurs dynamiques
-──────────────────────────────────
-API courante
-— with_capacity(n: i32)                  -> [T]
-— push(v: &mut [T], x: T)                -> ()
-— pop(v: &mut [T])                       -> Option<T>
-— len(v: [T])                            -> i32
-— get(v: [T], i: i32)                    -> Option<&T>
-
-Exemples
-  let mut v:[i32] = vec::with_capacity(16)
-  v.push(1); v.push(2)
-  for x in &v { io::println(x.to_string()) }
-  match v.pop() { Some(x) => io::println("last="+x.to_string()), None => {} }
-
-Bonnes pratiques
-— Accéder via `get(i)` si l’index peut dépasser; sinon tester `i < vec::len(v)`.
-
-Pièges
-— Hypothèses implicites sur la capacité → réserver avec `with_capacity` si connu.
-
-
-8.8 std.debug — Assertions et backtrace
-───────────────────────────────────────
-API courante
-— assert(cond: bool)                      -> ()
-— dump(x: affichable)                     -> ()   // aide au debug
-— backtrace()                             -> ()   // si -g et supporté
-
-Exemples
-  debug::assert(sum([1,2,3]) == 6)
-  debug::dump("state=INIT")
-
-Bonnes pratiques
-— Assertions pour invariants internes; messages clairs à l’échec.
-— Activer `-g` en debug pour des traces exploitables.
-
-Pièges
-— Laisser des `dump` verbeux en prod. Garder les traces essentielles.
-
-
-8.9 std.err — Erreurs canoniques
-─────────────────────────────────
-Concept
-— `err::Error` rassemble des informations d’échec (catégorie, message, contexte).
-— La stdlib retourne souvent `Result<T, err::Error>`.
-
-Motifs communs
-— I/O: chemins, droits, formats.
-— FFI: codes retour négatifs, pointeurs invalides.
-
-Bonnes pratiques
-— Enrichir l’erreur avec contexte applicatif avant de la remonter.
-— Normaliser les codes de sortie (0 OK, 1 panic, 2 usage, 3 I/O, 4 FFI).
-
-Pièges
-— Déguiser un panic en `Err` ou inversement. Séparer fatal/récupérable.
-
-
-8.10 std.c — Pont C et mémoire bas niveau
-──────────────────────────────────────────
-API courante
-— CString::from_str(s: str)              -> Result<CString, str>
-— malloc(size: usize)                    -> *mut u8        // unsafe
-— free(ptr: *mut u8)                     -> ()             // unsafe
-
-Interop
-— Déclarer:
-    extern "C" { fn puts(msg:*const char) -> i32 }
-— Appeler:
-    let cmsg = c::CString::from_str("Hello\n")?
-    unsafe { _ = puts(cmsg.as_ptr()) }
-
-Bonnes pratiques
-— Réduire la surface `unsafe` au strict minimum.
-— Documenter qui alloue/libère chaque buffer.
-— Pour strings, toujours passer par `CString::from_str`.
-
-Pièges
-— Passer un `str` non null-terminé côté C.
-— Oublier `free` sur mémoire allouée côté C quand c’est votre responsabilité.
-
-
-8.11 Patterns composés — recettes rapides
-──────────────────────────────────────────
-Lecture fichier + parse int avec erreurs explicites
-  fn load_threshold(path: str) -> Result<i64, err::Error> {
-      let s = fs::read_to_string(path)?
-      match str::to_int(str::replace(s, "\n", "")) {
-          Result::Ok(v) => return Result::Ok(v),
-          Result::Err(_) => return Result::Err(err::Error::new("parse int échoué")),
-      }
-  }
-
-Timer simple autour d’une fonction
-  fn timed<F>(label: str, f: F) -> ()
-  where F: fn()->()
-  {
-      let t0 = time::now()
-      f()
-      io::println(label + ": " + (time::now()-t0).to_string() + " ms")
-  }
-
-CLI robuste (usage + codes de sortie)
-  fn main() -> i32 {
-      let a = cli::args()
-      if str::len(a) < 2 {
-          io::eprintln("usage: app <input>")
-          return 2
-      }
-      if !fs::exists(a[1]) {
-          io::eprintln("E2001: introuvable → " + a[1])
-          return 3
-      }
-      // …
-      return 0
-  }
-
-
-8.12 Conseils par niveau
-────────────────────────
-Débutant
-— Commencer avec io/fs/str/cli uniquement.
-— Toujours vérifier `exists` avant `read_to_string`.
-
-Intermédiaire
-— Structurer les erreurs avec `Result` et messages utiles.
-— Mesurer avec `time::now()` pour cibler l’optimisation.
-
-Pro
-— Envelopper les APIs C via `std.c` avec un shim C stable.
-— Centraliser la gestion d’erreurs `err::Error` + mapping vers codes de sortie.
-— Garder un niveau de logs cohérent et mesuré.
-
-
-──────────────────────────────────────────────
-9) STYLE ET BONNES PRATIQUES — GUIDE DÉTAILLÉ
-─────────────────────────────────────────────
-
-But
-— Donner une cohérence à tous les projets Vitte Light.
-— Aider les débutants à écrire du code lisible dès le départ.
-— Permettre aux intermédiaires de maintenir des bases de code claires.
-— Donner aux pros un style stable, compatible avec l’outillage (fmt, lint).
-
-─────────────────────────────────────────────
-9.1 Structure générale des fichiers
-───────────────────────────────────
-1) Toujours commencer par le `module` :
-   — C’est la “carte d’identité” du fichier.
-   — Exemple : fichier `src/math/linear.vitl` → `module app.math.linear`
-
-2) Grouper immédiatement les `import` :
-   — Tous les imports en bloc, sans code entre eux.
-   — Les regrouper par hiérarchie.
-   — Exemple :
-     ```
-     module app.main
-     import std.{io, fs}
-     import app.math.linear
-     ```
-
-3) Code du module ensuite :
-   — Constantes
-   — Types (struct, enum)
-   — Implémentations
-   — Fonctions
-   — Tests
-
-─────────────────────────────────────────────
-9.2 Nommage (variables, fonctions, types)
-─────────────────────────────────────────────
-Convention :
-— snake_case → variables, fonctions locales, noms de fichiers.
-— CamelCase → structs, enums, modules publics.
-
-Exemples :
-  let user_name = "Alice"
-  fn compute_area(w:i32, h:i32) -> i32 { return w*h }
-
-  struct Rectangle { width:i32, height:i32 }
-  enum Status { Ok, Failed }
-
-Pourquoi ?
-— snake_case : lisible et courant dans la majorité des langages modernes.
-— CamelCase : met en évidence les types et les concepts de haut niveau.
-
-─────────────────────────────────────────────
-9.3 Constantes et immutabilité
-─────────────────────────────────────────────
-— Toujours utiliser `const` pour les valeurs fixes :
-
-
-
-──────────────────────────────────────────────
-
-10) CONSEILS PAR NIVEAU
-───────────────────────
-Débutant :
-- Utilisez `println` pour voir vos résultats.
-- Commencez par des programmes courts (< 50 lignes).
-- Explorez `vitl fmt` pour apprendre le style standard.
-
-Intermédiaire :
-- Utilisez `test` pour vérifier vos fonctions.
-- Manipulez fichiers avec `std.fs`.
-- Maîtrisez `?` pour simplifier le code d’erreurs.
-
-Pro :
-- Intégrez des libs C via FFI.
-- Activez optimisations `-O3`.
-- Explorez `--emit-ir` pour analyser votre code.
-- Combinez VITL avec CI/CD (Makefile, CMake, GitHub Actions).
-
-──────────────────────────────────────────────
-
-11) LIMITES (VERSION LIGHT) — VERSION DÉTAILLÉE
-───────────────────────────────────────────────
-But
-— Clarifier ce qui n’existe pas encore dans Vitte Light (VITL), pourquoi, et comment contourner proprement.
-— Donner des recettes adaptées aux débutants, intermédiaires, pros.
-
-Résumé court
-— Pas de threads natifs.
-— Pas de GC complet (seulement Rc/Weak).
-— Génériques partiels uniquement.
-— FFI limité au C (ABI C).
-
-───────────────────────────────────────────────
-11.1 Pas de threads natifs
-──────────────────────────
-Ce que cela signifie
-— Aucune API VITL pour créer des threads. Pas de synchronisation (mutex, condvar) dans la stdlib VITL.
-
-Conséquences
-— Pas de parallélisme CPU intra-processus directement en VITL.
-— Les tâches concurrentes doivent être séquencées ou externalisées.
-
-Stratégies de contournement
-Débutant
-— Sérialiser le travail : découper en étapes, mesurer, optimiser l’algorithme.
-— Utiliser des fichiers temporaires ou des pipes simples pour enchaîner des outils externes (exécutés via le shell/OS).
-
-Intermédiaire
-— **Multi-processus** via FFI C (en écrivant un petit shim C qui fork/exec) et communication par *stdin/stdout* (pipes) ou fichiers.
-— **Pipelines** : lancer plusieurs instances du binaire VITL et répartir les lots de données.
-
-Pro
-— Encapsuler un runtime de threads externe (C, Rust, Go… exposé en C ABI) et appeler ses fonctions via FFI.
-— Choisir le bon modèle : *fan-out/fan-in* avec orchestration dans un parent VITL, chaque worker = process natif externe.
-— Limiter la granularité : tâches “grosses” pour amortir le coût IPC.
-
-Antipatterns
-— Simuler des “threads” avec boucles agressives et I/O bloquantes → gaspillage CPU.
-— Multiplier les processus sans contrôle de ressources → contention disque/mémoire.
-
-Checklist
-[ ] Avez-vous réellement besoin de parallélisme ?  
-[ ] Les parties lourdes sont-elles externalisables dans un binaire C/Rust appelé par VITL ?  
-[ ] Les canaux de communication sont-ils bornés et robustes aux erreurs/temps morts ?  
-
-───────────────────────────────────────────────
-11.2 Pas de GC complet (seulement Rc/Weak)
-────────────────────────────────────────────
-Ce que cela signifie
-— Gestion mémoire sûre par **références comptées** (Rc<T>) et références faibles (Weak<T>).
-— Pas de ramasse-miettes tracing. Pas de déplacement automatique d’objets. Pas de collecte de cycles automatique.
-
-Conséquences
-— Les cycles forts (A → B → A) **ne sont pas libérés** automatiquement.
-— Les performances sont prévisibles (pas de pause GC), mais l’architecture doit éviter les cycles.
-
-Stratégies de conception
-Débutant
-— Préférer des structures arborescentes sans références en arrière.
-— Passer des données par valeur quand c’est petit et fréquent (i32, f64…).
-
-Intermédiaire
-— Utiliser **Weak** pour les pointeurs “retour” (parent) et **Rc** pour les pointeurs “avant” (enfants).
-— Documenter la topologie (qui possède quoi). Une seule direction en **fort**, l’autre en **faible**.
-
-Pro
-— Introduire des *zones de vie* et des frontières claires entre propriétaires et observateurs.
-— Auditer régulièrement (revue de code) les graphes d’objets susceptibles de former des cycles.
-— Si nécessaire, encapsuler un allocateur/arena côté C via FFI pour des patterns haute fréquence (pools, slab).
-
-Exemple (rupture de cycle)
-Mauvais (cycle fort):
-  // A::child -> Rc<B>, B::parent -> Rc<A>  (cycle)
-Correct (parent faible):
-  // A::child -> Rc<B>, B::parent -> Weak<A>
-
-Checklist
-[ ] Les relations parents/enfants évitent-elles les cycles forts ?  
-[ ] Les valeurs volumineuses sont-elles partagées via Rc et lues majoritairement ?  
-[ ] Les buffers temporaires élevés en fréquence sont-ils réutilisés (éviter l’allocation répétée) ?  
-
-───────────────────────────────────────────────
-11.3 Génériques partiels uniquement
-──────────────────────────────────
-Ce que cela signifie
-— Les types/génériques existent de façon limitée (principalement dans la stdlib).
-— Moins de métaprogrammation que dans Vitte “complet” ou Rust.
-
-Conséquences
-— API “générique” parfois moins flexible.
-— Possibles duplications de code quand les types varient beaucoup.
-
-Stratégies de conception
-Débutant
-— Commencer avec des types concrets (i32, f64, String). Éviter d’abstraire trop tôt.
-— Favoriser des fonctions simples et spécialisées.
-
-Intermédiaire
-— Factoriser par **interfaces de données** (formats texte, lignes, enregistrements) au lieu de viser la généricité type-paramétrée.
-— Utiliser des adaptateurs minces : convertisseurs `to_string()`, `parse()` côté std.str.
-
-Pro
-— Déporter la généricité “lourde” dans une lib C/Rust accessible via FFI C (sur quelques points chauds seulement).
-— Stabiliser vos **types de domaine** (DTO) et isoler les conversions aux frontières de module.
-— Intégrer des tests de non-régression lors des changements de type.
-
-Checklist
-[ ] Les fonctions publiques ont-elles des signatures **stables** et explicites ?  
-[ ] Les conversions de types sont-elles centralisées et testées ?  
-[ ] Les points nécessitant de la généricité forte sont-ils délégués à FFI si critique ?  
-
-───────────────────────────────────────────────
-11.4 FFI limité au C (ABI C)
-────────────────────────────
-Ce que cela signifie
-— Seule l’interface binaire C est supportée nativement.
-— C++/Rust/Go/etc. doivent exposer un **shim C** (`extern "C"`) pour être appelés.
-
-Conséquences
-— Pas de passage direct d’objets complexes non-C.
-— Convention d’appel et représentation mémoire = C.
-
-Stratégies d’intégration
-Débutant
-— S’en tenir aux appels simples : fonctions C pures, entrées/sorties primitives, buffers.
-— Toujours construire les chaînes avec `std.c::CString::from_str` avant de passer au C.
-
-Intermédiaire
-— Écrire un **shim C** propre : API plate, types opaques (`void*` + fonctions d’accès), fonctions `create()/destroy()`.
-— Vérifier les codes retour et convertir vers `Result`.
-
-Pro
-— Définir une **ABI stable** (semver) côté C, tests d’intégration croisés (VITL ↔ C).
-— Mesurer l’overhead d’appels FFI et grouper les opérations pour amortir le coût.
-— Gérer explicitement l’allocation/désallocation croisée (qui possède le buffer ? qui le libère ?).
-
-Exemple de pattern FFI
-C (shim):
-  struct Obj;
-  Obj* obj_create(int cap);
-  void  obj_destroy(Obj*);
-  int   obj_push(Obj*, const char* s);  // 0=OK, <0=err
-  int   obj_len(const Obj*);
-
-VITL:
-  extern "C" {
-    fn obj_create(cap:i32)->*mut void
-    fn obj_destroy(p:*mut void)->void
-    fn obj_push(p:*mut void, s:*const char)->i32
-    fn obj_len(p:*const void)->i32
-  }
-  // Construire CString, appeler dans unsafe, vérifier codes retour.
-
-Checklist
-[ ] Le shim expose-t-il uniquement des types C stables (int, double, void*, char*) ?  
-[ ] Les responsabilités d’allocation/libération sont-elles documentées ?  
-[ ] Chaque appel renvoie-t-il un code d’erreur testable, converti en `Result` côté VITL ?  
-
-───────────────────────────────────────────────
-11.5 Décider quand “sortir” des limites
-─────────────────────────────────────────────
-Règle pratique
-— Si la fonctionnalité manque et que l’**algorithme** suffit à compenser → rester 100% VITL.
-— Si les contraintes sont structurelles (threads, généricité lourde, GC) → **isoler** la partie critique dans une lib C/Rust avec shim C et piloter depuis VITL.
-
-Matrice rapide
-— Performance CPU brute → déléguer le cœur à C/Rust (FFI).  
-— I/O intensif séquentiel → VITL convient, optimiser le format et les buffers.  
-— Concurrence massive → multi-processus ou runtime externe via FFI.  
-— Modèles de données dynamiques et très polymorphes → fixer des DTO stables + shims.
-
-───────────────────────────────────────────────
-11.6 Contrats de qualité autour des limites
-────────────────────────────────────────────
-— Tests : pour chaque contour, fournir au moins 1 test succès + 1 test erreur.
-— Logs : enrichir les messages d’erreur avec contexte (fichier, taille, chemin).
-— Docs : annoter les fonctions “limites” avec `///` précisant invariants et coûts.
-— Bench : garder un micro-benchmark des chemins FFI et des I/O.
-
-Fin de la section 11.
-
-
-──────────────────────────────────────────────
-
-12) CODES DE SORTIE
-────────────────────
-0 → succès  
-1 → erreur générique/panic  
-2 → erreur d’usage CLI  
-3 → erreur I/O  
-4 → erreur FFI
-
-──────────────────────────────────────────────
-11) DIAGNOSTICS COURANTS — VERSION DÉTAILLÉE
-────────────────────────────────────────────
-
-But
-— Donner pour chaque code : symptôme, causes probables, correctifs, exemples.
-— Cible débutants → comprendre le message. Intermédiaires → corriger vite. Pros → outillage.
-
-Outils utiles
-— Lint :        vitl check src/
-— Build debug : vitl build -g -O0 -o build/app src/main.vitl
-— IR/BC :       vitl build --emit-ir     | vitl build --emit-bytecode
-— Traces :      std.debug::backtrace()   | panic("msg")
-— Recherche :   vitl doc src/ -o build/docs.txt
-
-Notation
-— « Mauvais » = exemple fautif. « Correct » = correction minimale.
-
-
-E0001 : symbole inconnu
-───────────────────────
-Symptôme
-— Le compilateur ne trouve pas une fonction, un type, un module ou une constante.
-
-Causes fréquentes
-— Import manquant ou chemin de module incorrect.
-— Typo dans le nom (majuscules/minuscules).
-— Déplacement de fichier sans mise à jour de `module` en tête.
-— API renommée lors d’une refactorisation.
-
-Correctifs standard
-— Ajouter l’import précis ou corriger le chemin.
-— Vérifier que `module` en tête correspond au chemin disque.
-— Lancer `vitl fmt` pour regrouper et stabiliser les imports.
-
-Exemples
-Mauvais:
-  module app.main
-  fn main()->i32 {
-    std.io::pritnln("hi")   // typo
-    return 0
-  }
-
-Correct:
-  module app.main
-  import std.io
-  fn main()->i32 {
-    std.io::println("hi")
-    return 0
-  }
-
-Astuce pro
-— Préférer `import std.{io, fs}` pour expliciter le périmètre.
-— `vitl check` pointe la ligne et la colonne exactes.
-
-
-E0002 : types incompatibles
-───────────────────────────
-Symptôme
-— Une expression du type A est passée là où B est attendu.
-
-Causes fréquentes
-— Addition mélangeant `i32` et `f64`.
-— Appel d’API avec paramètre de type attendu différent.
-— Comparaison stricte entre types non convertibles.
-
-Correctifs standard
-— Ajouter un cast explicite `as` quand la perte d’info est acceptée.
-— Adapter la signature de la fonction ou l’appelant pour unifier les types.
-— Introduire une conversion préalable (ex. `to_string()`).
-
-Exemples
-Mauvais:
-  let n:i32 = 3
-  let x:f64 = 0.5
-  let y = n + x     // E0002
-
-Correct (1 — cast local):
-  let n:i32 = 3
-  let x:f64 = 0.5
-  let y = (n as f64) + x
-
-Correct (2 — normaliser l amont):
-  let n:f64 = 3.0
-  let x:f64 = 0.5
-  let y = n + x
-
-Autres patterns
-— Chaînes:
-    std.io::println("n=" + n)        // E0002
-    std.io::println("n=" + n.to_string())   // OK
-
-Astuce pro
-— Stabiliser les types aux frontières d’API publiques (types explicites).
-— `vitl check` repère aussi les conversions implicites dangereuses.
-
-
-E0003 : variable non initialisée
-────────────────────────────────
-Symptôme
-— Utilisation d’une variable qui n’a pas reçu de valeur sur tous les chemins.
-
-Causes fréquentes
-— Déclaration séparée de l’initialisation.
-— Chemin `if/else` non exhaustif.
-— Retour prématuré avant affectation.
-
-Correctifs standard
-— Initialiser à la déclaration.
-— Rendre les branches exhaustives.
-— Restructurer en `match` pour couvrir tous les cas.
-
-Exemples
-Mauvais:
-  let mut acc:i32
-  if cond { acc = 1 }
-  // cond=false → acc non assignée
-  std.io::println(acc.to_string())   // E0003
-
-Correct:
-  let mut acc:i32 = 0
-  if cond { acc = 1 }
-  std.io::println(acc.to_string())
-
-Autre:
-  let x:i32
-  if a { x = 1 } else { x = 2 }
-  // ici OK car exhaustif
-
-Astuce pro
-— Éviter les « variables sentinelles »; préférer un `match` retournant une valeur.
-
-
-E1001 : appel FFI non-safe hors bloc unsafe
-────────────────────────────────────────────
-Symptôme
-— Appel d’une fonction C ou manipulation de pointeurs bruts sans `unsafe`.
-
-Causes fréquentes
-— Oubli du bloc `unsafe { ... }`.
-— Conversion de chaîne en `CString` non vérifiée.
-— Passage d’un pointeur invalide à une API C.
-
-Correctifs standard
-— Envelopper *uniquement* l’appel risqué dans `unsafe`.
-— Construire les `CString` via `std.c::CString::from_str`.
-— Assurer la durée de vie des buffers passés au C.
-
-Exemples
-Mauvais:
-  extern "C" { fn puts(msg:*const char)->i32 }
-  fn main()->i32 {
-    let s = std.c::CString::from_str("Hi\n")
-    puts(s.as_ptr())          // E1001
-    return 0
-  }
-
-Correct:
-  extern "C" { fn puts(msg:*const char)->i32 }
-  fn main()->i32 {
-    let s = std.c::CString::from_str("Hi\n")
-    unsafe { _ = puts(s.as_ptr()) }
-    return 0
-  }
-
-Astuce pro
-— Réduire la surface `unsafe` au strict minimum.
-— Valider les tailles et null-terminators côté VITL avant l’appel.
-
-
-E2001 : fichier introuvable (I/O)
-─────────────────────────────────
-Symptôme
-— Échec d’ouverture/lecture d’un fichier par la stdlib (erreur au runtime).
-
-Causes fréquentes
-— Chemin relatif interprété depuis un répertoire inattendu.
-— Fichier non copié ou supprimé.
-— Droits insuffisants, montage absent.
-
-Correctifs standard
-— Tester l’existence avant lecture.
-— Utiliser des chemins absolus pour les ressources système.
-— Gérer l’erreur avec `Result` et message contextuel.
-
-Exemples
-Mauvais:
-  let txt = std.fs::read_to_string("data/config.txt")?   // E2001
-
-Correct:
-  let path = "data/config.txt"
-  if !std.fs::exists(path) {
-    std.io::eprintln("config manquante: " + path)
-    return 3
-  }
-  let txt = std.fs::read_to_string(path)?
-
-
-Annexe A — Diagnostics supplémentaires courants
-───────────────────────────────────────────────
-E0100 : variable non utilisée
-— Contexte: le code compile mais une variable n est jamais lue.
-— Correction: supprimer la variable, ou prefixer `_var` pour marquer volontaire.
-
-E0101 : code inatteignable
-— Contexte: instructions après `return` ou après un `match` exhaustif.
-— Correction: retirer la portion morte ou factoriser les branches.
-
-E0201 : division par zéro détectable
-— Contexte: `x / 0` littéral connu au compile-time.
-— Correction: vérifier dénominateur, valider en amont.
-
-E0301 : dépassement d’index (runtime)
-— Contexte: `v[i]` hors bornes.
-— Correction: tester `i < v.len()`, ou utiliser `get(i)` qui retourne `Option`.
-
-E0401 : pattern `match` non exhaustif
-— Contexte: manque un cas, surtout avec `enum`.
-— Correction: ajouter `_ => {...}` ou toutes les variantes.
-
-E0501 : conflit mutabilité simple
-— Contexte: tentative d’écrire dans une donnée non `mut`.
-— Correction: déclarer `let mut x` ou cloner/retourner une nouvelle valeur.
-
-E0601 : format de chaîne invalide
-— Contexte: concat de types non-string sans `to_string()`.
-— Correction: convertir avant concaténation.
-
-E0701 : échec FFI (résultat négatif)
-— Contexte: fonction C renvoie code erreur.
-— Correction: vérifier le code retour, convertir en `Result::Err(...)` côté VITL.
-
-E0801 : UTF-8 invalide lors d une lecture texte
-— Contexte: contenu binaire lu via `read_to_string`.
-— Correction: utiliser `std.fs::read` (bytes) puis décoder conditionnellement.
-
-
-Annexe B — Stratégie de triage (checklist rapide)
-──────────────────────────────────────────────────
-1) Lire le message complet et la ligne ciblée.
-2) Lancer `vitl check` pour lints supplémentaires.
-3) Si import/symbole: vérifier `module` et `import`.
-4) Si types: normaliser les types en amont, cast explicite si nécessaire.
-5) Si non initialisé: initialiser à la déclaration ou rendre les branches exhaustives.
-6) Si FFI: entourer par `unsafe`, valider les pointeurs et durées de vie.
-7) Si I/O: controler `std.fs::exists`, chemins absolus, droits.
-8) Recompiler avec `-g` et activer `std.debug::backtrace()` en cas de crash.
-9) Ajouter des `test` minimaux pour reproduire le bug.
-10) Documenter la cause et le correctif en commentaire `///` si API publique.
-
-
-Annexe C — Exemples de messages enrichis côté application
-──────────────────────────────────────────────────────────
-— I/O robuste:
   let path = argv[1]
-  if !std.fs::exists(path) {
-    std.io::eprintln("E2001: fichier introuvable → " + path)
-    std.io::eprintln("Astuce: lancer depuis la racine du projet ou passer un chemin absolu.")
+  if !fs::exists(path) {
+    io::eprintln("introuvable:" + path)
     return 3
   }
+  let contenu = fs::read_to_string(path)?  // propage l'erreur I/O
+  io::print(contenu)
+  return 0
+}
+</code></pre>
+<pre><code># Exécution
+vitl run src/cat.vitl -- data.txt
+</code></pre>
+      <ul>
+        <li>OK : affiche le contenu.</li>
+        <li>Erreur d’usage : code 2.</li>
+        <li>Fichier manquant : code 3.</li>
+      </ul>
+<pre><code>// Variante A (binaire)
+let bytes = fs::read(path)?
+io::println("taille=" + bytes.len().to_string())
 
-— FFI robuste:
-  let msg = std.c::CString::from_str("ok\n")
-  if msg.is_err() {
-    return Result::Err("E0601: CString invalide (caractère nul)")
+// Variante B (chrono)
+let t0 = std.time::now()
+let contenu = fs::read_to_string(path)?
+io::println("ms=" + (std.time::now() - t0).to_string())
+
+// Variante C (multi-fichiers)
+for i in 1..str::len(argv) {
+  let p = argv[i]
+  if !fs::exists(p) { io::eprintln("skip:" + p); continue }
+  io::print(fs::read_to_string(p)?)
+}
+</code></pre>
+
+      <h3>4.3 Pro → struct, impl, méthodes</h3>
+<pre><code>// src/geom.vitl
+module app.geom
+import std.{io, math}
+
+struct Vec2 { x: f64, y: f64 }
+
+impl Vec2 {
+  fn norm(&amp;self) -&gt; f64 { return (self.x*self.x + self.y*self.y).sqrt() }
+  fn dot(&amp;self, o: Vec2) -&gt; f64 { return self.x*o.x + self.y*o.y }
+}
+
+fn main() -&gt; i32 {
+  let v = Vec2 { x: 3.0, y: 4.0 }
+  io::println(v.norm().to_string()) // 5
+  return 0
+}
+
+// Tests intégrés
+test "norm classique 3-4-5" {
+  let v = Vec2 { x:3.0, y:4.0 }
+  assert(v.norm() == 5.0)
+}
+test "dot produit orthogonal" {
+  let a = Vec2 { x:1.0, y:0.0 }
+  let b = Vec2 { x:0.0, y:1.0 }
+  assert(a.dot(b) == 0.0)
+}
+</code></pre>
+<pre><code>// Variante A (parse CLI)
+import std.{cli, str}
+fn parse_f64(s: str) -&gt; Result&lt;f64, str&gt; { return str::to_float(s) }
+fn main() -&gt; i32 {
+  let a = cli::args()
+  if str::len(a) != 3 {
+    io::eprintln("usage: geom &lt;x&gt; &lt;y&gt;"); return 2
   }
-  unsafe { _ = puts(msg.unwrap().as_ptr()) }
+  let x = parse_f64(a[1])?
+  let y = parse_f64(a[2])?
+  let v = Vec2 { x:x, y:y }
+  io::println(v.norm().to_string())
+  return 0
+}
 
+// Variante B (mini-bench)
+fn bench(n: i32) -&gt; i32 {
+  let mut acc:f64 = 0.0
+  let base = Vec2 { x:1.234, y:5.678 }
+  for i in 0..n {
+    let v = Vec2 { x: base.x + (i as f64), y: base.y - (i as f64) }
+    acc = acc + v.norm()
+  }
+  std.io::println("acc=" + acc.to_string())
+  return 0
+}
+fn main() -&gt; i32 {
+  let t0 = std.time::now()
+  _ = bench(100000)
+  std.io::println("ms=" + (std.time::now()-t0).to_string())
+  return 0
+}
+</code></pre>
 
-Annexe D — Bonnes pratiques pour éviter les diagnostics
-────────────────────────────────────────────────────────
-— Imports précis et groupés; `vitl fmt` après chaque session.
-— Types explicites aux frontières d’API (fonctions `pub`).
-— Tests unitaires pour chaque module; couvrir les erreurs attendues.
-— Logs de contexte avec codes d’erreur stables (E-codes ci-dessus).
-— Limiter `unsafe` et l’isoler; documenter les invariants attendus.
-— Préférer `Option`/`Result` aux valeurs sentinelles magiques.
-— Valider l’entrée utilisateur tôt; fail fast avec message clair.
+      <h3>4.4 Bonnes pratiques transverses</h3>
+      <ul>
+        <li>Style : <code>module</code> en tête, imports groupés, <code>snake_case</code> pour fonctions/variables, <code>CamelCase</code> pour types.</li>
+        <li>Erreurs : <code>?</code> pour I/O et parsing, codes de sortie (0,1,2,3,4).</li>
+        <li>Organisation : un fichier = un module; tests en fin de fichier.</li>
+        <li>Perf : <code>time::now()</code>, slices <code>[T]</code>, <code>vec::with_capacity</code>.</li>
+        <li>Sécurité : pas d’<code>unsafe</code> hors FFI; utiliser <code>CString</code> pour le C.</li>
+      </ul>
+    </section>
 
-Fin de la section 10.
+    <hr />
 
-14) CHECKLIST AVANT DE LIVRER
-─────────────────────────────
-[ ] module app.main défini  
-[ ] fn main()->i32 présent  
-[ ] imports réduits au nécessaire  
-[ ] vitl test passe avec succès  
-[ ] build/app généré dans /build  
+    <!-- 5) MEMOIRE -->
+    <section id="memoire">
+      <h2>5) Mémoire et sécurité — guide détaillé</h2>
 
-──────────────────────────────────────────────
+      <h3>5.1 Modèle mémoire en mode sûr</h3>
+      <ul>
+        <li>Pas de GC complexe, gestion via références comptées <code>Rc&lt;T&gt;</code>.</li>
+        <li>Libération immédiate quand le compteur tombe à zéro.</li>
+      </ul>
+<pre><code>let a = Rc&lt;int&gt;::new(42)
+let b = a.clone()  // forts = 2
+a.drop()           // forts = 1
+b.drop()           // forts = 0 → libération
+</code></pre>
+      <p>Avantages : simplicité, déterminisme, sécurité. Limites : cycles <em>forts</em> non collectés → utiliser <code>Weak</code>.</p>
 
-─────────────────────────────────────────────
+      <h3>5.2 Immutabilité et mutabilité</h3>
+<pre><code>// str immuable ; String mutable
+let mut s = String::from("abc")
+s.push("d")  // "abcd"
+</code></pre>
+
+      <h3>5.3 Collections et slices</h3>
+<pre><code>let v:[i32] = [1,2,3,4]
+for x in &amp;v { io::println(x.to_string()) }
+</code></pre>
+      <p>Pré-allouer avec <code>vec::with_capacity</code> quand la taille est connue.</p>
+
+      <h3>5.4 Mode <code>unsafe</code> et pointeurs bruts</h3>
+<pre><code>extern "C" { fn puts(msg:*const char)-&gt;i32 }
+let cstr = std.c::CString::from_str("hi\n")?
+unsafe { puts(cstr.as_ptr()) }
+</code></pre>
+      <p>Encapsuler l’<code>unsafe</code> dans des fonctions VITL sûres.</p>
+
+      <h3>5.5 Par niveau</h3>
+      <p>Débutant : pas de <code>free()</code>, éviter <code>unsafe</code>. · Intermédiaire : <code>Rc/Weak</code>, slices, <code>str</code> vs <code>String</code>. · Pro : graphes via <code>Weak</code>, FFI encapsulé, allocateurs custom côté C si besoin.</p>
+
+      <h3>5.6 Erreurs courantes</h3>
+      <ul>
+        <li>Cycles <code>Rc</code> → fuite.</li>
+        <li>Passer une <code>String</code> temporaire au C → pointeur dangling.</li>
+        <li>Oublier <code>mut</code> → erreur compilation.</li>
+        <li><code>unsafe</code> non encapsulé.</li>
+      </ul>
+
+      <h3>5.7 Récapitulatif</h3>
+      <p>Gestion sûre via <code>Rc/Weak</code> · pas de GC · <code>str</code> immuable / <code>String</code> mutable · slices évitent les copies · <code>unsafe</code> réservé au FFI.</p>
+    </section>
+
+    <hr />
+
+    <!-- 6) ERREURS -->
+    <section id="erreurs">
+      <h2>6) Gestion des erreurs</h2>
+      <p>Type standard : <code>Result&lt;T, E&gt;</code> avec <code>Ok(T)</code> / <code>Err(E)</code>. Propagation avec <code>?</code>.</p>
+<pre><code>let contenu = fs::read_to_string("config.txt")?
+</code></pre>
+<pre><code>match fs::read_to_string("config.txt") {
+  Result::Ok(txt) =&gt; println(txt),
+  Result::Err(e)  =&gt; eprintln(e),
+}
+</code></pre>
+      <p><code>panic("msg")</code> : erreur irrécupérable, arrêt du programme.</p>
+    </section>
+
+    <hr />
+
+    <!-- 7) FFI -->
+    <section id="ffi">
+      <h2>7) Interopérabilité C (FFI) — guide avancé</h2>
+      <p>But — Appeler du code C en sécurité, définir un shim C portable, gérer chaînes/buffers/erreurs/édition de liens.</p>
+
+      <h3>7.1 Déclaration et appel minimal</h3>
+<pre><code>extern "C" { fn puts(msg: *const char) -&gt; i32 }
+let cstr = std.c::CString::from_str("Hello C!\n")?
+unsafe { _ = puts(cstr.as_ptr()) }
+
+// lien à la libc (ex.)
+vitl build -O2 -L libs -lc -o build/app src/main.vitl
+</code></pre>
+
+      <h3>7.2 Chaînes et ownership</h3>
+      <ul>
+        <li>Entrée VITL→C : construire via <code>CString::from_str</code>, conserver la durée de vie.</li>
+        <li>Retour C→VITL : copier si buffer interne, sinon libérer avec l’allocateur documenté (ex. <code>c::free</code>).</li>
+      </ul>
+
+      <h3>7.3 Buffers binaires et slices</h3>
+<pre><code>extern "C" { fn sha256(data:*const u8, len:usize, out:*mut u8) -&gt; i32 }
+let mut out:[u8] = [0; 32]
+unsafe { _ = sha256(input.as_ptr(), input.len(), out.as_mut_ptr()) }
+</code></pre>
+
+      <h3>7.4 Structs : opacité</h3>
+<pre><code>// C (shim)
+typedef struct Obj Obj;
+Obj* obj_create(int cap);
+void obj_destroy(Obj*);
+int  obj_push(Obj*, const char*);
+int  obj_len(const Obj*);
+
+// VITL
+extern "C" {
+  fn obj_create(cap:i32)-&gt;*mut void
+  fn obj_destroy(p:*mut void)-&gt;void
+  fn obj_push(p:*mut void, s:*const char)-&gt;i32
+  fn obj_len(p:*const void)-&gt;i32
+}
+</code></pre>
+
+      <h3>7.5 Erreurs et mapping <code>Result</code></h3>
+<pre><code>fn c_call_ok(code:i32) -&gt; Result&lt;(),str&gt; {
+  if code == 0 { return Result::Ok(()) }
+  return Result::Err("ffi: call failed")
+}
+</code></pre>
+
+      <h3>7.6 Callbacks et <code>user_data</code></h3>
+      <p>Gérer les callbacks dans le shim C, VITL fournit un identifiant opaque.</p>
+
+      <h3>7.7 Linking : <code>-L</code>, <code>-l</code>, rpath, static</h3>
+<pre><code># Dylib partagée
+vitl build -O2 -L libs -lfoo -o build/app src/main.vitl
+
+# Statique (si dispo)
+vitl build -O2 -L libs -Wl,-Bstatic -lfoo -Wl,-Bdynamic -o build/app src/main.vitl
+
+# rpath
+vitl build ... -Wl,-rpath,/chemin/vers/libs
+</code></pre>
+
+      <h3>7.8 Cross-plateforme</h3>
+      <p>Types stables (<code>int32_t</code>, <code>uint64_t</code>, <code>size_t</code>), éviter <code>long</code>, attention à l’alignement.</p>
+
+      <h3>7.9 Sécurité mémoire : règles d’or</h3>
+      <ul>
+        <li>Bornes vérifiées, pas de double free.</li>
+        <li>Chaînes null-terminées côté C.</li>
+        <li>Ne pas garder de pointeur C vers une <code>String</code> temporaire.</li>
+      </ul>
+
+      <h3>7.10 Exemple complet : wrapper « safe »</h3>
+<pre><code>// C (shim libfoo)
+typedef struct Foo Foo;
+Foo* foo_create(int cap); void foo_destroy(Foo*);
+int foo_push(Foo*, const char*); int foo_len(const Foo*);
+
+// VITL
+extern "C" {
+  fn foo_create(cap:i32)-&gt;*mut void
+  fn foo_destroy(h:*mut void)-&gt;void
+  fn foo_push(h:*mut void, s:*const char)-&gt;i32
+  fn foo_len(h:*const void)-&gt;i32
+}
+struct Foo { handle:*mut void }
+fn Foo::new(cap:i32) -&gt; Result&lt;Foo,str&gt; {
+  let h = unsafe { foo_create(cap) }
+  if h == std.ptr::null_mut() { return Result::Err("ffi: create failed") }
+  return Result::Ok(Foo{ handle:h })
+}
+fn Foo::push(&amp;mut self, s:str) -&gt; Result&lt;(),str&gt; {
+  let cstr = std.c::CString::from_str(s)?
+  let rc = unsafe { foo_push(self.handle, cstr.as_ptr()) }
+  if rc != 0 { return Result::Err("ffi: push failed") }
+  return Result::Ok(())
+}
+fn Foo::len(&amp;self) -&gt; i32 { return unsafe { foo_len(self.handle) } }
+fn Foo::close(&amp;mut self) -&gt; () {
+  if self.handle != std.ptr::null_mut() {
+    unsafe { foo_destroy(self.handle) }
+    self.handle = std.ptr::null_mut()
+  }
+}
+</code></pre>
+
+      <h3>7.11 Stratégie d’équipe et CI</h3>
+      <p>Figer l’interface C, tests d’intégration, builder shim + exécutable, publier artefacts (lib+header+sha), documenter rpath/paths.</p>
+
+      <h3>7.12 Quand FFI n’est pas le bon outil</h3>
+      <p>Regrouper les appels (batch), formats binaires compacts, runtime externe pour threads natifs.</p>
+
+      <p class="card"><strong>Résumé</strong> — ABI C, handles opaques, <code>CString</code>, <code>ptr+len</code>, <code>Result</code>, surface <code>unsafe</code> minimale.</p>
+    </section>
+
+    <hr />
+
+    <!-- 8) STDLIB -->
+    <section id="stdlib">
+      <h2>8) Stdlib — aperçu détaillé</h2>
+      <p>Convention — Fonctions système retournent <code>Result&lt;...&gt;</code>, <code>?</code> propage. Extraits supposent : <code>import std.{io, fs, str, math, time, cli, vec, debug, err, c}</code>.</p>
+
+      <h3>8.1 std.io — E/S console</h3>
+      <p>API : <code>print</code>, <code>println</code>, <code>eprint</code>, <code>eprintln</code>.</p>
+<pre><code>io::println("Hello")
+io::eprintln("fatal: config manquante")
+</code></pre>
+
+      <h3>8.2 std.fs — Fichiers et chemins</h3>
+<pre><code>let cfg = fs::read_to_string("config.toml")?
+_ = fs::write_string("out.txt", "ok\n")?
+if !fs::exists("data.bin") { io::eprintln("absent: data.bin"); return 3 }
+</code></pre>
+
+      <h3>8.3 std.str — Chaînes et utilitaires</h3>
+<pre><code>let n = str::len("abc")     // 3
+let parts = str::split("a b c", ' ')
+let idx = str::find("abc","b") // 1
+let out = str::replace("a_b","_","-") // "a-b"
+let v = str::to_int("42")?   // i64
+</code></pre>
+
+      <h3>8.4 std.math — Maths</h3>
+<pre><code>let d = math::sqrt(3.0*3.0 + 4.0*4.0) // 5.0
+let a = math::abs(-12) // 12
+</code></pre>
+
+      <h3>8.5 std.time — Horloge</h3>
+<pre><code>let t0 = time::now()
+heavy()
+io::println((time::now() - t0).to_string() + " ms")
+</code></pre>
+
+      <h3>8.6 std.cli — Arguments/env</h3>
+<pre><code>let argv = cli::args()
+if str::len(argv) &lt; 2 {
+  io::eprintln("usage: app &lt;file&gt;"); return 2
+}
+match cli::env("HOME") {
+  Some(h) =&gt; io::println(h),
+  None =&gt; io::eprintln("HOME non défini"),
+}
+</code></pre>
+
+      <h3>8.7 std.vec — Vecteurs</h3>
+<pre><code>let mut v:[i32] = vec::with_capacity(16)
+v.push(1); v.push(2)
+for x in &amp;v { io::println(x.to_string()) }
+match v.pop() { Some(x) =&gt; io::println("last="+x.to_string()), None =&gt; {} }
+</code></pre>
+
+      <h3>8.8 std.debug — Assertions</h3>
+<pre><code>debug::assert(sum([1,2,3]) == 6)
+debug::dump("state=INIT")
+</code></pre>
+
+      <h3>8.9 std.err — Erreurs</h3>
+      <p><code>err::Error</code> regroupe catégorie/message/contexte. Mapping vers codes de sortie conseillé.</p>
+
+      <h3>8.10 std.c — Pont C</h3>
+<pre><code>extern "C" { fn puts(msg:*const char) -&gt; i32 }
+let cmsg = c::CString::from_str("Hello\n")?
+unsafe { _ = puts(cmsg.as_ptr()) }
+</code></pre>
+
+      <h3>8.11 Patterns composés</h3>
+<pre><code>fn load_threshold(path: str) -&gt; Result&lt;i64, err::Error&gt; {
+  let s = fs::read_to_string(path)?
+  match str::to_int(str::replace(s, "\n", "")) {
+    Result::Ok(v) =&gt; return Result::Ok(v),
+    Result::Err(_) =&gt; return Result::Err(err::Error::new("parse int échoué")),
+  }
+}
+</code></pre>
+<pre><code>fn timed&lt;F&gt;(label: str, f: F) -&gt; ()
+where F: fn()-&gt;() {
+  let t0 = time::now()
+  f()
+  io::println(label + ":" + (time::now()-t0).to_string() + " ms")
+}
+</code></pre>
+
+      <h3>8.12 Conseils par niveau</h3>
+      <p>Débutant : io/fs/str/cli ; vérifier <code>exists</code>. · Intermédiaire : <code>Result</code> structuré, mesures. · Pro : shims C, <code>err::Error</code> centralisé, logs mesurés.</p>
+    </section>
+
+    <hr />
+
+    <!-- 9) STYLE -->
+    <section id="style">
+      <h2>9) Style et bonnes pratiques — guide détaillé</h2>
+
+      <h3>9.1 Structure générale des fichiers</h3>
+      <ol>
+        <li><strong>module</strong> en tête (ex. <code>module app.math.linear</code> pour <code>src/math/linear.vitl</code>).</li>
+        <li>Imports regroupés immédiatement après (par hiérarchie).</li>
+        <li>Ensuite : constantes → types → impl → fonctions → tests.</li>
+      </ol>
+
+      <h3>9.2 Nommage</h3>
+<pre><code>let user_name = "Alice"
+fn compute_area(w:i32, h:i32) -&gt; i32 { return w*h }
+
+struct Rectangle { width:i32, height:i32 }
+enum Status { Ok, Failed }
+</code></pre>
+
+      <h3>9.3 Constantes et immutabilité</h3>
+      <p>Toujours <code>const</code> pour les valeurs fixes ; immuable par défaut, <code>mut</code> au besoin.</p>
+    </section>
+
+    <hr />
+
+    <!-- 10) NIVEAUX -->
+    <section id="niveaux">
+      <h2>10) Conseils par niveau</h2>
+      <p><strong>Débutant</strong> : <code>println</code>, programmes &lt; 50 lignes, <code>vitl fmt</code>.</p>
+      <p><strong>Intermédiaire</strong> : <code>test</code>, <code>std.fs</code>, maîtriser <code>?</code>.</p>
+      <p><strong>Pro</strong> : FFI C, <code>-O3</code>, <code>--emit-ir</code>, CI/CD.</p>
+    </section>
+
+    <hr />
+
+    <!-- 11) LIMITES -->
+    <section id="limites">
+      <h2>11) Limites (version Light) — version détaillée</h2>
+      <p>Résumé : pas de threads natifs · pas de GC complet (Rc/Weak) · génériques partiels · FFI limité au C.</p>
+
+      <h3>11.1 Pas de threads natifs</h3>
+      <p>Stratégies : séquencer, multi-processus via FFI, pipelines, runtime externe.</p>
+
+      <h3>11.2 Pas de GC complet (Rc/Weak)</h3>
+      <p>Éviter les cycles forts, utiliser <code>Weak</code> pour liens retour, auditer les graphes.</p>
+
+      <h3>11.3 Génériques partiels</h3>
+      <p>Favoriser types concrets, interfaces de données, déporter la généricité lourde via FFI si critique.</p>
+
+      <h3>11.4 FFI limité au C (ABI C)</h3>
+      <p>Shim C requis pour C++/Rust/Go, API plate, handles opaques, responsabilités d’allocation documentées.</p>
+
+      <h3>11.5 Décider quand « sortir »</h3>
+      <p>Algorithme suffisant → rester VITL ; contraintes structurelles → isoler via lib externe + FFI.</p>
+
+      <h3>11.6 Contrats de qualité</h3>
+      <p>Tests (succès/erreur), logs contextualisés, docs <code>///</code>, micro-benchs I/O/FFI.</p>
+    </section>
+
+    <hr />
+
+    <!-- 12) CODES -->
+    <section id="codes-sortie">
+      <h2>12) Codes de sortie</h2>
+      <ul>
+        <li><strong>0</strong> → succès</li>
+        <li><strong>1</strong> → erreur générique/panic</li>
+        <li><strong>2</strong> → erreur d’usage CLI</li>
+        <li><strong>3</strong> → erreur I/O</li>
+        <li><strong>4</strong> → erreur FFI</li>
+      </ul>
+    </section>
+
+    <hr />
+
+    <!-- 13) DIAGNOSTICS -->
+    <section id="diagnostics">
+      <h2>13) Diagnostics courants — version détaillée</h2>
+      <p><strong>Outils</strong> : <code>vitl check</code> · <code>vitl build -g -O0</code> · <code>--emit-ir</code>/<code>--emit-bytecode</code> · <code>std.debug::backtrace()</code> · <code>vitl doc</code></p>
+
+      <h3>E0001 : symbole inconnu</h3>
+<pre><code>// Mauvais
+module app.main
+fn main()-&gt;i32 {
+  std.io::pritnln("hi")
+  return 0
+}
+
+// Correct
+module app.main
+import std.io
+fn main()-&gt;i32 {
+  std.io::println("hi")
+  return 0
+}
+</code></pre>
+
+      <h3>E0002 : types incompatibles</h3>
+<pre><code>// Mauvais
+let n:i32 = 3
+let x:f64 = 0.5
+let y = n + x
+
+// Correct (cast local)
+let n:i32 = 3
+let x:f64 = 0.5
+let y = (n as f64) + x
+
+// Chaînes
+std.io::println("n=" + n)           // E0002
+std.io::println("n=" + n.to_string()) // OK
+</code></pre>
+
+      <h3>E0003 : variable non initialisée</h3>
+<pre><code>// Mauvais
+let mut acc:i32
+if cond { acc = 1 }
+std.io::println(acc.to_string())
+
+// Correct
+let mut acc:i32 = 0
+if cond { acc = 1 }
+std.io::println(acc.to_string())
+</code></pre>
+
+      <h3>E1001 : FFI non-safe hors <code>unsafe</code></h3>
+<pre><code>// Mauvais
+extern "C" { fn puts(msg:*const char)-&gt;i32 }
+fn main()-&gt;i32 {
+  let s = std.c::CString::from_str("Hi\n")
+  puts(s.as_ptr())  // E1001
+  return 0
+}
+
+// Correct
+extern "C" { fn puts(msg:*const char)-&gt;i32 }
+fn main()-&gt;i32 {
+  let s = std.c::CString::from_str("Hi\n")
+  unsafe { _ = puts(s.unwrap().as_ptr()) }
+  return 0
+}
+</code></pre>
+
+      <h3>E2001 : fichier introuvable (I/O)</h3>
+<pre><code>// Correct
+let path = "data/config.txt"
+if !std.fs::exists(path) {
+  std.io::eprintln("config manquante:" + path)
+  return 3
+}
+let txt = std.fs::read_to_string(path)?
+</code></pre>
+
+      <h3>Annexe A — Diagnostics supplémentaires</h3>
+      <ul>
+        <li>E0100 : variable non utilisée → supprimer ou préfixer <code>_</code>.</li>
+        <li>E0101 : code inatteignable → retirer ou factoriser.</li>
+        <li>E0201 : division par zéro détectable.</li>
+        <li>E0301 : dépassement d’index → tester <code>i &lt; v.len()</code> ou <code>get(i)</code>.</li>
+        <li>E0401 : <code>match</code> non exhaustif.</li>
+        <li>E0501 : conflit de mutabilité.</li>
+        <li>E0601 : format de chaîne invalide (manque <code>to_string()</code>).</li>
+        <li>E0701 : échec FFI (code &lt; 0).</li>
+        <li>E0801 : UTF-8 invalide en lecture texte.</li>
+      </ul>
+
+      <h3>Annexe B — Stratégie de triage</h3>
+      <ol>
+        <li>Lire le message complet et la ligne.</li>
+        <li><code>vitl check</code> pour lints.</li>
+        <li>Vérifier <code>module</code>/<code>import</code>.</li>
+        <li>Normaliser/caster les types.</li>
+        <li>Initialiser à la déclaration / branches exhaustives.</li>
+        <li>FFI : <code>unsafe</code> + pointeurs/durées validés.</li>
+        <li>I/O : <code>exists</code>, chemins, droits.</li>
+        <li>Rebuild <code>-g</code> + backtrace.</li>
+        <li>Tests minimaux pour reproduire.</li>
+        <li>Doc <code>///</code> cause + correctif.</li>
+      </ol>
+
+      <h3>Annexe C — Messages enrichis</h3>
+<pre><code>// I/O robuste
+let path = argv[1]
+if !std.fs::exists(path) {
+  std.io::eprintln("E2001: fichier introuvable → " + path)
+  std.io::eprintln("Astuce: lancer depuis la racine du projet ou passer un chemin absolu.")
+  return 3
+}
+</code></pre>
+<pre><code>// FFI robuste
+let msg = std.c::CString::from_str("ok\n")
+if msg.is_err() { return Result::Err("E0601: CString invalide (caractère nul)") }
+unsafe { _ = puts(msg.unwrap().as_ptr()) }
+</code></pre>
+
+      <h3>Annexe D — Prévenir les diagnostics</h3>
+      <ul>
+        <li>Imports précis et groupés ; <code>vitl fmt</code> fréquent.</li>
+        <li>Types explicites aux frontières d’API.</li>
+        <li>Tests unitaires par module (succès/erreurs attendues).</li>
+        <li>Logs contextualisés avec codes d’erreur stables.</li>
+        <li><code>unsafe</code> minimal et documenté.</li>
+        <li>Préférer <code>Option</code>/<code>Result</code> aux sentinelles.</li>
+        <li>Valider l’entrée tôt ; fail fast.</li>
+      </ul>
+    </section>
+
+    <hr />
+
+    <!-- 14) CHECKLIST -->
+    <section id="checklist">
+      <h2>14) Checklist avant de livrer</h2>
+      <ul>
+        <li>[ ] <code>module app.main</code> défini</li>
+        <li>[ ] <code>fn main()-&gt;i32</code> présent</li>
+        <li>[ ] imports réduits au nécessaire</li>
+        <li>[ ] <code>vitl test</code> passe</li>
+        <li>[ ] <code>build/app</code> généré dans <code>/build</code></li>
+      </ul>
+      <p class="note">FIN DU GUIDE</p>
+    </section>
+
+  </main>
+</body>
+</html>

--- a/docs/doc.md
+++ b/docs/doc.md
@@ -1,310 +1,2021 @@
-VITTE LIGHT — GUIDE UTILISATEUR (TXT)
+
+VITTE LIGHT — GUIDE UTILISATEUR COMPLET
 Révision: 2025-09-05
+──────────────────────────────────────────────
 
-──────────────────────────────────────────────────────────────────────────────
-0) OBJECTIF
-Vitte Light (VITL) est un langage minimal inspiré de Vitte, même syntaxe de base.
-Cible: programmes CLI rapides, scripts compilés, embeddings C.
-Ce document couvre: structure de projet, CLI, syntaxe, stdlib, FFI, exemples.
+0) INTRODUCTION — VITTE LIGHT
+─────────────────────────────
+Vitte Light (abrégé **VITL**) est un langage minimaliste, dérivé du langage Vitte, 
+conçu pour allier **syntaxe moderne**, **simplicité d’usage** et **outillage complet**.  
+Il vise trois profils de développeurs : débutants, intermédiaires, professionnels.
 
-──────────────────────────────────────────────────────────────────────────────
-1) FICHIERS, EXTENSIONS, ENCODAGE
-- Source: .vitl
-- Encodage: UTF-8 sans BOM
-- Convention modules: noms en snake.case, chemins hiérarchiques
-  Exemple: module std.io correspond à std/io.vitl
+─────────────────────────────
+0.1 Philosophie du langage
+─────────────────────────────
+— Minimalisme : garder un cœur réduit de fonctionnalités, faciles à apprendre.  
+— Cohérence : syntaxe claire, pas de règles cachées, erreurs explicites.  
+— Polyvalence : exécution immédiate via VM, compilation native, intégration en C.  
+— Sécurité : gestion mémoire déterministe (références comptées), 
+  erreurs explicites (Result, panic).  
+— Portabilité : fonctionne sur Linux, BSD, macOS, Windows.  
 
-Arbo simple:
-  /src
-    main.vitl
-  /libs           # libs .c/.a/.so/.dll si FFI
-  /build          # artefacts
+─────────────────────────────
+0.2 Pour qui est fait VITL ?
+─────────────────────────────
+**Débutant**  
+— Découvrir la programmation avec une syntaxe simple et lisible.  
+— Ne pas se perdre dans la complexité (pointeurs, mémoire manuelle, GC lourd).  
+— Apprendre progressivement des concepts modernes : immutabilité, Result, match.  
 
-──────────────────────────────────────────────────────────────────────────────
-2) OUTILS EN LIGNE DE COMMANDE
-Selon distribution, soit binaire unique `vitl`, soit couple `vitlc` (compileur),
-`vitlv` (VM/runner). Les deux formes ci-dessous sont supportées.
+**Développeur intermédiaire**  
+— Écrire des scripts rapides et compacts pour automatiser des tâches.  
+— Construire de petites applications CLI portables.  
+— Profiter d’un formateur, d’un linter et de tests intégrés.  
 
-Exécution directe (JIT/VM):
-  vitl run src/main.vitl
-ou:
-  vitlv run src/main.vitl
+**Professionnel**  
+— Compiler en exécutable natif optimisé (-O3).  
+— Exploiter le FFI C stable pour réutiliser des bibliothèques existantes.  
+— Intégrer VITL dans des workflows CI/CD et packager des outils distribuables.  
+— Inspecter IR et bytecode (`--emit-ir`, `--emit-bytecode`) pour analyser la compilation.  
 
-Compilation → exécutable natif:
-  vitl build -O2 -o build/app src/main.vitl
-ou:
-  vitlc -O2 -o build/app src/main.vitl
+─────────────────────────────
+0.3 Domaines d’utilisation
+─────────────────────────────
+1. **Écriture rapide de scripts CLI**  
+   — Remplacer Bash/Python dans certains cas avec un langage typé.  
+   — Automatiser des tâches système, parser des fichiers, manipuler du texte.  
 
-Autres:
-  vitl fmt path/                  # formateur
-  vitl check src/                 # analyse statique
-  vitl test                       # lance tests intégrés
-  vitl doc src/ -o build/docs.txt # extrait commentaires ///
+2. **Compilation en exécutables natifs**  
+   — Créer de petits binaires autonomes, rapides à exécuter.  
+   — Idéal pour distribution, packaging, embarqué.  
+   — Compatible multi-plateformes (Linux, BSD, macOS, Windows).  
 
-Options communes:
-  -O0/-O1/-O2/-O3, -g, --emit-ir, --emit-bytecode, --no-stdlib, -I <dir>, -L <dir>, -l<name>
+3. **Langage embarqué (FFI C)**  
+   — Intégrer VITL dans des projets existants en C.  
+   — Charger du code utilisateur compilé en bytecode `.vitbc`.  
+   — Fournir un langage de script extensible pour un moteur ou un outil.  
 
-──────────────────────────────────────────────────────────────────────────────
-3) SYNTAXE ESSENTIELLE (IDENTIQUE À VITTE)
-Lexique:
-  - Ident: [A-Za-z_][A-Za-z0-9_]*
-  - Commentaires: // ligne, /* bloc */
-  - Séparateurs: ; optionnel en fin de ligne si non ambigu
+─────────────────────────────
+0.4 Points forts de VITL
+─────────────────────────────
+✓ Syntaxe lisible et unifiée (identique à Vitte).  
+✓ Gestion mémoire simple et prévisible (Rc/Weak).  
+✓ Erreurs explicites avec `Result` et propagation `?`.  
+✓ Standard library (I/O, fichiers, chaînes, maths, temps, vecteurs).  
+✓ Outils intégrés : formateur (`fmt`), linter (`check`), tests (`test`), doc (`doc`).  
+✓ Exécution directe ou compilation native optimisée.  
+✓ FFI C stable et facile à utiliser.  
 
-Littéraux:
-  - Entiers: 0, 42, 1_000, 0xFF, 0o755, 0b1010
-  - Flottants: 3.14, 1e-9
-  - Bool: true, false
-  - Char: 'a', '\n'
-  - String: "texte", r"brut"
-
-Types de base:
-  i8 i16 i32 i64  u8 u16 u32 u64  f32 f64  bool char  str
-  arrays: [T; N]   slices: [T]    tuples: (T1, T2)    option: Option<T>
-  pointeurs bas niveau si activés: *T, *mut T   (mode unsafe)
-
-Déclarations:
-  module app.main                  // un par fichier
-  import std.io
-  import std.{fs, time}            // import groupé
-
-  const PI: f64 = 3.1415926535
-  let mut x: i32 = 0
-  let y = 123                      // inférence
-
-Fonctions:
-  fn add(a: i32, b: i32) -> i32 { return a + b }
-  fn main() -> i32 {
-    std.io::println("Hello");
-    return 0
-  }
-
-Contrôle:
-  if cond { ... } else { ... }
-  while cond { ... }
-  for i in 0..10 { ... }           // 0..10 exclusif, 0..=10 inclusif
-  match v {
-    0 => std.io::println("zero"),
-    1 | 2 => std.io::println("small"),
-    _ => {}
-  }
-
-Structures et enums:
-  struct Point { x: f64, y: f64 }
-  enum Result<T, E> { Ok(T), Err(E) }
-
-Méthodes et impl:
-  impl Point {
-    fn norm(&self) -> f64 { return (self.x*self.x + self.y*self.y).sqrt() }
-  }
-
-Erreurs:
-  fn f() -> Result<i32, str> { return Result::Ok(42) }
-  let r = f()
-  match r { Result::Ok(v) => {}, Result::Err(e) => std.io::eprintln(e) }
-
-Assertions/tests:
-  assert(x == 4)
-  test "sum works" { assert(add(2,2) == 4) }
-
-──────────────────────────────────────────────────────────────────────────────
-4) ENTRÉE/SORTIE (STD)
-E/S console:
-  std.io::print("txt")
-  std.io::println("txt")
-  std.io::eprintln("err")
-
-Fichiers:
-  let data = std.fs::read_to_string("file.txt")?
-  std.fs::write_string("out.txt", "hello")?
-
-Temps:
-  let now = std.time::now()
-
-Chaînes:
-  let s = "hi " + name
-  let n = std.str::len(s)
-  let parts = std.str::split(s, ' ')
-
-Args, exit:
-  let argv = std.cli::args()
-  std.sys::exit(0)
-
-`?` propage l’erreur sous forme Result; équivaut à match court.
-
-──────────────────────────────────────────────────────────────────────────────
-5) GESTION MÉMOIRE
-- Automatique par comptage de références (Rc) en mode sûr.
-- `unsafe` autorise pointeurs bruts et FFI manuel.
-- Slices vues non propriétaires; strings immuables `str`, mutables via `String`.
-
-Exemples rapides:
-  let mut v: [i32] = std.vec::with_capacity(16)
-  v.push(1); v.push(2)
-  for x in &v { std.io::println(x.to_string()) }
-
-──────────────────────────────────────────────────────────────────────────────
-6) ERREURS ET TRAITEMENT
-Type canonique: Result<T, E>
-- Fonctions std retournent Result avec E=std.err::Error ou str.
-- Opérateur `?` remonte l’erreur.
-- `panic("msg")` pour erreurs irrécupérables; exit code ≠ 0.
-
-──────────────────────────────────────────────────────────────────────────────
-7) FFI C (OPTIONNEL)
-Déclarer signatures externes:
-  extern "C" {
-    fn puts(msg: *const char) -> i32
-  }
-
-Appel:
-  let cstr = std.c::CString::from_str("Hello\n")
-  unsafe { _ = puts(cstr.as_ptr()) }
-
-Lien:
-  vitl build -L libs -lc -o build/app src/main.vitl
-  # ou -l<libname> pour lib<name>.so/.dll/.a
-
-──────────────────────────────────────────────────────────────────────────────
-8) EXEMPLES CONCIS
-
-8.1 Hello CLI
+─────────────────────────────
+0.5 Exemple rapide (Hello World)
+─────────────────────────────
+Code :
   module app.main
   import std.io
-  fn main() -> i32 { std.io::println("Hello, Vitte Light"); return 0 }
 
-8.2 Somme, tests
-  module app.math
-  fn sum(xs: [i32]) -> i32 {
-    let mut s = 0
-    for x in xs { s = s + x }
-    return s
-  }
-  test "sum" { assert(sum([1,2,3]) == 6) }
-
-8.3 Lecture fichier avec `?`
-  module app.cat
-  import std.{fs, io}
   fn main() -> i32 {
-    let argv = std.cli::args()
-    if std.len(argv) < 2 { io::eprintln("usage: cat <file>"); return 2 }
-    let txt = fs::read_to_string(argv[1])?
-    io::print(txt)
+    std.io::println("Bonjour Vitte Light")
     return 0
   }
 
-8.4 Enum et match
-  module app.http
-  enum Code { Ok, NotFound, Other(i32) }
-  fn descr(c: Code) -> str {
-    match c { Code::Ok => "200", Code::NotFound => "404", Code::Other(x) => "X" }
+Exécution :
+  vitl run src/main.vitl
+
+Compilation :
+  vitl build -O2 -o build/app src/main.vitl
+  ./build/app
+
+─────────────────────────────
+Résumé
+— **Débutant** : apprendre la programmation moderne sans complexité inutile.  
+— **Intermédiaire** : écrire des scripts compacts, robustes et portables.  
+— **Pro** : bénéficier d’un compilateur performant, d’un FFI C stable et d’une toolchain complète.  
+— Trois usages principaux : scripting CLI, compilation native, intégration embarquée.  
+
+
+
+──────────────────────────────────────────────
+
+1) STRUCTURE DE PROJET — GUIDE COMPLET
+──────────────────────────────────────
+Un projet VITL repose sur une organisation stricte des dossiers et fichiers.
+Cette rigueur facilite la navigation, la compilation et l’intégration dans des 
+outils externes (CMake, Meson, CI/CD, IDE).
+
+──────────────────────────────────────
+1.1 Arborescence type minimale
+──────────────────────────────────────
+/src      → code source principal (.vitl)
+/libs     → bibliothèques natives C/FI (.c, .so, .dll, .a)
+/build    → binaires compilés, artefacts intermédiaires, bytecode (.vitbc)
+
+Exemple :
+  mon_projet/
+    src/
+      main.vitl
+      util/str.vitl
+    libs/
+      mylib.c
+      mylib.a
+    build/
+      app            (binaire natif)
+      app.vitbc      (bytecode compilé)
+
+──────────────────────────────────────
+1.2 Convention des modules
+──────────────────────────────────────
+— Un fichier correspond à un module unique.
+— Le chemin disque reflète le nom du module.
+— Le nom de module s’écrit en `snake.case`.
+
+Exemple :
+  Fichier : src/std/io.vitl
+  Contenu : module std.io
+
+Règle : **hiérarchie dossier = hiérarchie de module**.
+
+Bénéfices :
+— Import clair et intuitif :
+     import std.io
+     import util.str
+— Évite les conflits de noms.
+— Favorise la réutilisation de modules indépendants.
+
+──────────────────────────────────────
+1.3 Organisation recommandée
+──────────────────────────────────────
+Niveaux typiques d’un projet :
+
+/src
+  app/              → logique applicative (main, modules spécifiques)
+  std/              → standard library locale/complémentaire
+  util/             → utilitaires internes (par ex. parsing, formatage)
+
+/libs
+  externe/          → wrappers C tiers (sqlite.c, ssl.c…)
+  interne/          → code C maison à exposer via FFI
+
+/build
+  debug/            → builds avec -O0 -g
+  release/          → builds optimisés avec -O3
+  docs/             → documentation générée par `vitl doc`
+
+──────────────────────────────────────
+1.4 Raison d’être de la rigueur
+──────────────────────────────────────
+Débutant
+— Vous savez toujours où chercher vos fichiers.
+— Le projet reste simple à lire, même avec plusieurs sources.
+
+Intermédiaire
+— Séparation claire entre code applicatif et librairies natives.
+— Possibilité de réutiliser un module sans embarquer tout le projet.
+— Tests plus faciles : `vitl test` explore /src et repère vos fichiers.
+
+Pro
+— Packaging plus simple (chaque dossier a un rôle précis).
+— CI/CD : scripts de build ciblent `/src` et exportent dans `/build`.
+— Compatibilité naturelle avec outils externes (CMake, Meson, Ninja).
+— FFI C propre : tout ce qui est natif est dans `/libs`, sans polluer `/src`.
+
+──────────────────────────────────────
+1.5 Variantes de structure
+──────────────────────────────────────
+Projet simple (script unique)
+  /src/main.vitl
+
+Projet moyen (appli CLI avec libs perso)
+  /src/
+    main.vitl
+    cli/args.vitl
+    math/geom.vitl
+  /libs/
+    fastmath.c
+  /build/
+
+Projet complexe (grosse appli avec tests et doc)
+/src/
+  app/
+    main.vitl
+    net/http.vitl
+    net/tcp.vitl
+  core/
+    error.vitl
+    config.vitl
+/tests/
+  test_math.vitl
+  test_net.vitl
+/libs/
+  sqlite/
+    sqlite3.c
+/build/
+  debug/
+  release/
+  docs/
+
+──────────────────────────────────────
+1.6 Conseils pratiques
+──────────────────────────────────────
+— Toujours commencer un fichier source par :
+     module chemin.nom
+— Grouper les imports immédiatement après.
+— Garder /src pour le code VITL, /libs pour le C natif, /build pour les binaires.
+— Ajouter /tests si le projet grandit, et y placer uniquement des modules de tests.
+— Ne jamais mélanger artefacts compilés et sources dans le même dossier.
+
+──────────────────────────────────────
+Résumé
+✓ /src : code VITL (modules).  
+✓ /libs : code natif pour FFI.  
+✓ /build : binaires et docs.  
+✓ Nom module = chemin fichier.  
+✓ Structure stricte = lisibilité, maintenabilité, intégration CI/CD.
+
+
+──────────────────────────────────────────────
+2) OUTILS EN LIGNE DE COMMANDE — GUIDE COMPLET
+──────────────────────────────────────────────
+Vitte Light (VITL) propose un environnement de compilation et d’exécution 
+via une CLI (Command Line Interface). Selon la distribution, tu peux avoir :
+
+— Un binaire unique `vitl`
+   → combine compilation, VM, outils (fmt, check, test, doc).
+— Un couple `vitlc` (compilateur) et `vitlv` (machine virtuelle)
+   → approche plus modulaire, utile si tu veux séparer build et exécution.
+
+──────────────────────────────────────────────
+2.1 Exécution immédiate (VM/JIT)
+──────────────────────────────────────────────
+Commande :
+  vitl run src/main.vitl
+ou :
+  vitlv run src/main.vitl
+
+Explications :
+— Le code source est lu, compilé en bytecode, puis exécuté directement par la VM.
+— Idéal pour tester rapidement un script sans passer par la compilation native.
+— La VM vérifie aussi certains invariants (sécurité mémoire, erreurs de syntaxe).
+
+Cas d’usage :
+— Débutant : écrire un petit script et voir le résultat instantanément.
+— Intermédiaire : prototypage rapide avant intégration.
+— Pro : usage pour tests automatisés dans CI/CD (exécution sans build).
+
+Erreur fréquente :
+— Oublier le chemin du fichier → `vitl run` sans argument affiche l’aide.
+
+──────────────────────────────────────────────
+2.2 Compilation en exécutable natif
+──────────────────────────────────────────────
+Commande :
+  vitl build -O2 -o build/app src/main.vitl
+ou :
+  vitlc -O2 -o build/app src/main.vitl
+
+Explications :
+— Génère un binaire exécutable natif (Linux, BSD, macOS, Windows selon cible).
+— -O2 active des optimisations standards (taille/rapidité équilibrée).
+— Le résultat se trouve dans `/build` par convention.
+
+Avantages :
+— Démarrage instantané (pas besoin de VM).
+— Binaire autonome, facile à distribuer.
+— Plus de performance pour des calculs lourds.
+
+Cas d’usage :
+— Intermédiaire : distribuer un outil CLI interne.
+— Pro : créer un exécutable pour production, packagé avec CI/CD.
+
+──────────────────────────────────────────────
+2.3 Outils supplémentaires
+──────────────────────────────────────────────
+**Formateur automatique**  
+  vitl fmt src/  
+— Réorganise imports, corrige indentation, uniformise accolades.  
+— Conseillé pour tous : garde un style homogène entre équipes.
+
+**Analyse statique**  
+  vitl check src/  
+— Détecte variables inutilisées, branches mortes, conversions implicites.  
+— Intermédiaire/Pro : indispensable avant commit ou merge.
+
+**Tests unitaires**  
+  vitl test  
+— Exécute tous les blocs `test "nom" { ... }` définis dans le code.  
+— Débutant : apprendre à valider ses fonctions.  
+— Pro : automatiser la validation dans pipelines CI.
+
+**Documentation automatique**  
+  vitl doc src/ -o build/docs.txt  
+— Extrait les commentaires `///` en documentation utilisateur.  
+— Pro : permet de livrer une doc synchronisée avec le code.
+
+──────────────────────────────────────────────
+2.4 Options utiles
+──────────────────────────────────────────────
+— `-O0` : pas d’optimisation, build rapide pour debug.  
+— `-O1` : optimisation légère.  
+— `-O2` : compromis vitesse/taille (valeur par défaut).  
+— `-O3` : optimisations agressives (inlining, unroll).  
+— `-g`  : inclut symboles de debug, nécessaire pour `std.debug::backtrace`.  
+
+Exemple debug :
+  vitl build -O0 -g -o build/app src/main.vitl
+  ./build/app
+
+— `--emit-ir` : imprime l’IR (Intermediate Representation) lisible par humain.  
+— `--emit-bytecode` : génère un fichier `.vitbc` (format binaire standardisé).  
+
+Cas d’usage :
+— Étudiant/chercheur : `--emit-ir` pour étudier la compilation.  
+— Pro : `--emit-bytecode` pour intégrer VITBC dans un pipeline VM.
+
+──────────────────────────────────────────────
+2.5 Bonnes pratiques CLI
+──────────────────────────────────────────────
+Débutant :
+— Utiliser `vitl run` pour tester rapidement.
+— Ajouter `vitl fmt` pour s’habituer au style standard.
+
+Intermédiaire :
+— Compiler avec `vitl build -O2 -g` pour avoir à la fois optimisation et debug.
+— Vérifier le code avec `vitl check` avant tout commit.
+
+Pro :
+— Intégrer `vitl test` et `vitl check` dans une pipeline CI/CD.
+— Distribuer des exécutables compilés avec `-O3` pour prod.
+— Générer docs avec `vitl doc` pour livrer aux utilisateurs.
+
+──────────────────────────────────────────────
+2.6 Erreurs fréquentes
+──────────────────────────────────────────────
+— E0001 : fichier introuvable → chemin incorrect dans la commande.
+— Permission denied → oublier `chmod +x` sur un binaire généré.
+— Mauvais ordre d’options → `-o build/app` doit suivre la commande `build`.
+
+──────────────────────────────────────────────
+Résumé
+— `vitl run` : exécution directe dans la VM.  
+— `vitl build` : compilation en exécutable natif.  
+— `vitl fmt`, `vitl check`, `vitl test`, `vitl doc` : outillage quotidien.  
+— Options -O et -g : choisir entre debug et performance.  
+— Outils pensés pour couvrir du **prototype rapide** jusqu’au **binaire distribué**.
+
+
+
+──────────────────────────────────────────────
+
+3) SYNTAXE : DÉCOUVERTE PROGRESSIVE
+────────────────────────────────────
+But
+— Apprendre les briques de base de Vitte Light (VITL).
+— Comprendre la logique derrière chaque construction.
+— Éviter les erreurs classiques de syntaxe ou de typage.
+
+────────────────────────────────────
+3.1 Commentaires
+────────────────
+Types de commentaires :
+— Ligne unique : commence par `//`, ignore tout jusqu’à la fin de la ligne.
+— Bloc : délimité par `/* … */`, peut couvrir plusieurs lignes.
+
+Exemple :
+  // ceci est un commentaire simple
+  let x = 42  // vous pouvez aussi commenter après une instruction
+
+  /*
+     commentaire multi-lignes
+     utile pour désactiver temporairement un bloc de code
+  */
+
+Bonne pratique
+— Utiliser `//` pour notes rapides.
+— Utiliser `/* … */` pour documenter un algorithme ou désactiver du code.
+
+────────────────────────────────────
+3.2 Variables et constantes
+───────────────────────────
+Déclaration :
+— `const` : valeur immuable et connue à la compilation.
+— `let`   : variable liée à une valeur. Par défaut immuable.
+— `let mut` : variable mutable.
+
+Exemples :
+  const PI: f64 = 3.14159     // constante avec type explicite
+  let mut compteur: i32 = 0   // variable modifiable
+  let message = "Salut"       // type inféré automatiquement = str
+
+Inférence de type
+— Le compilateur déduit le type si ce n’est pas ambigu.
+— Pour une API publique, toujours annoter le type explicitement.
+
+Erreur fréquente
+— Oublier `mut` :
+    let n = 0
+    n = n + 1    // erreur → variable non mutable
+  Correct :
+    let mut n = 0
+    n = n + 1
+
+────────────────────────────────────
+3.3 Fonctions
+────────────────
+Syntaxe :
+  fn nom(param: Type, ...) -> TypeRetour {
+    // corps
+    return valeur
   }
 
-8.5 Struct + méthodes
-  module app.geo
-  struct Vec2 { x: f64, y: f64 }
-  impl Vec2 { fn dot(&self, o: Vec2) -> f64 { return self.x*o.x + self.y*o.y } }
+Exemple :
+  fn add(a: i32, b: i32) -> i32 {
+    return a + b
+  }
 
-──────────────────────────────────────────────────────────────────────────────
-9) FORMATTEUR ET LINT
-- `vitl fmt` aligne imports, retire espaces, normalise accolades.
-- `vitl check` signale variables non utilisées, branches mortes, conversions implicites.
+Notes
+— Le mot-clé `fn` introduit une fonction.
+— Paramètres typés explicitement.
+— Le `return` indique la valeur renvoyée.
+— Si la fonction ne renvoie rien : `-> ()`.
 
-Règles de style abrégées:
-- Module au début de fichier, imports regroupés.
-- Types explicites aux API publiques.
-- snake_case pour fonctions/vars, CamelCase pour types.
+Variante courte
+  fn square(x: i32) -> i32 { return x*x }
 
-──────────────────────────────────────────────────────────────────────────────
-10) DIAGNOSTICS COURANTS
-E0001: symbole inconnu
-  → vérifier import ou nom du module
-E0002: types incompatibles
-  → caster explicitement: x as i32
-E0003: variable non initialisée
-E1001: appel FFI non-safe hors bloc unsafe
-E2001: fichier introuvable (std.fs::read_*)
+Erreur fréquente
+— Oublier `-> TypeRetour` :
+    fn bad(x: i32) { return x*x }   // erreur : manque le type
 
-──────────────────────────────────────────────────────────────────────────────
-11) BUILD AVANCÉ
-IR/Bytecode:
-  --emit-ir         # imprime IR lisible
-  --emit-bytecode   # écrit .vitbc (VITBC) dans /build
+────────────────────────────────────
+3.4 Structures de contrôle
+──────────────────────────
+Conditionnelle `if`
+  if x > 0 {
+    println("positif")
+  } else {
+    println("non positif")
+  }
 
-Optimisations:
-  -O2 par défaut; -O3 active inlining agressif et unroll
-Débogage:
-  -g + std.debug::backtrace() si supporté
+Boucle `for`
+— Itère sur un intervalle ou une collection.
+— Intervalle exclusif `0..10` → 0 à 9.
+— Intervalle inclusif `0..=10` → 0 à 10.
 
-Cross-build:
-  vitlc --target x86_64-linux-gnu -O2 -o build/app src/main.vitl
+Exemple :
+  for i in 0..10 {
+    println(i.to_string())
+  }
 
-──────────────────────────────────────────────────────────────────────────────
-12) MINI GRAMMAIRE (EBNF RÉSUMÉ)
-  Module    = "module", Ident, {".", Ident} ;
-  Import    = "import", Path, [ "{", Ident, {",", Ident}, "}" ] ;
-  Decl      = Const | Let | Fn | Struct | Enum | Impl ;
-  Const     = "const", Ident, ":", Type, "=", Expr ;
-  Let       = "let", ["mut"], Ident, [":", Type], "=", Expr ;
-  Fn        = "fn", Ident, "(", [Params], ")", ["->", Type], Block ;
-  Struct    = "struct", Ident, "{", Fields, "}" ;
-  Enum      = "enum", Ident, "{", Variants, "}" ;
-  Impl      = "impl", Ident, Block ;
-  Block     = "{", {Stmt}, "}" ;
-  Stmt      = Let | Expr | Return | If | While | For | Match | ";"
-  Return    = "return", [Expr] ;
-  If        = "if", Expr, Block, ["else", Block] ;
-  While     = "while", Expr, Block ;
-  For       = "for", Ident, "in", Expr, Block ;
-  Match     = "match", Expr, "{", Arms, "}" ;
+Boucle `while`
+  let mut n = 0
+  while n < 5 {
+    println(n.to_string())
+    n = n + 1
+  }
 
-──────────────────────────────────────────────────────────────────────────────
-13) STDLIB (SURVOL MINIMAL)
-  std.io    : print, println, eprint, eprintln
-  std.fs    : read_to_string, read, write_string, write, exists
-  std.str   : len, split, find, replace, to_int, to_float
-  std.math  : abs, sqrt, sin, cos, pow
-  std.time  : now, sleep_ms
-  std.cli   : args, env, exit
-  std.vec   : with_capacity, push, pop, len, get
-  std.err   : Error, display
-  std.debug : assert, dump, backtrace
-  std.c     : CString, malloc/free (unsafe)
+Erreur fréquente
+— Boucle infinie non voulue (oublier d’incrémenter un compteur).
 
-──────────────────────────────────────────────────────────────────────────────
-14) CONVENTIONS D’EXIT
-  0  succès
-  1  erreur générique/panic
-  2  erreur d’usage CLI
-  3  I/O
-  4  FFI/chargement lib
+────────────────────────────────────
+3.5 Match (pattern matching puissant)
+────────────────────────────────────
+`match` compare une valeur à différents motifs.
 
-──────────────────────────────────────────────────────────────────────────────
-15) RECETTES RAPIDES
+Exemple simple :
+  match valeur {
+    0 => println("zéro"),
+    1 | 2 => println("petit"),   // alternative avec |
+    _ => println("autre")        // _ = cas par défaut
+  }
 
-Lecture JSON en texte brut (sans parser dédié):
-  let raw = std.fs::read_to_string("cfg.json")?
-  if std.str::find(raw, "\"enabled\": true") >= 0 { std.io::println("on") }
+Exemple avec enum :
+  enum Status { Ok, Err(str) }
 
-Mesure de durée:
+  let s = Status::Err("oops")
+
+  match s {
+    Status::Ok => println("ok"),
+    Status::Err(msg) => println("erreur: " + msg),
+  }
+
+Avantages
+— Plus expressif que des if/else imbriqués.
+— Forçage à couvrir tous les cas (sauf si `_` utilisé).
+
+Erreur fréquente
+— Oublier un cas dans un `match` exhaustif :
+    enum Color { Red, Green, Blue }
+    match c {
+      Color::Red => println("rouge"),
+      Color::Green => println("vert")
+    }
+  → erreur : cas `Blue` manquant
+
+────────────────────────────────────
+3.6 Types de base et littéraux
+──────────────────────────────
+Entiers :
+— Décimaux : 0, 42, 1_000
+— Hexa : 0xFF
+— Octal : 0o755
+— Binaire : 0b1010
+
+Flottants :
+— 3.14, 2.0e-3
+
+Booléens :
+— true, false
+
+Caractères :
+— 'a', '\n'
+
+Chaînes :
+— "texte normal"
+— r"brut sans échappement"
+
+────────────────────────────────────
+3.7 Bonnes pratiques de style
+─────────────────────────────
+Débutant
+— Déclarer vos variables avec `let` et types simples.
+— Utiliser `println` pour vérifier les valeurs.
+
+Intermédiaire
+— Isoler les tests dans des fonctions et utiliser `assert`.
+— Toujours traiter tous les cas d’un `match`.
+
+Pro
+— Factoriser vos contrôles avec `match` au lieu d’empiler des `if`.
+— Éviter les conversions implicites ; soyez explicite avec `as`.
+
+────────────────────────────────────
+Résumé
+— Commentaires : `//` ou `/* … */`.
+— Variables : immuables par défaut, `mut` si nécessaire.
+— Fonctions : `fn nom(param: Type) -> Type`.
+— Contrôle : `if`, `while`, `for`.
+— Pattern matching : `match`, exhaustif et clair.
+
+
+──────────────────────────────────────────────
+
+4) PREMIERS EXEMPLES — DÉTAILLÉS
+────────────────────────────────
+Objectif
+— T’aider à écrire, exécuter, compiler et tester trois programmes “types”.
+— Montrer les erreurs fréquentes et leurs corrections.
+— Donner des variantes utiles pour aller un cran plus loin.
+
+Pré-requis
+— Arbo conseillée :
+    /src
+      main.vitl        (exemple débutant)
+      cat.vitl         (exemple intermédiaire)
+      geom.vitl        (exemple pro)
+— Exécution VM :
+    vitl run src/main.vitl
+— Compilation native :
+    vitl build -O2 -o build/app src/main.vitl
+
+
+4.1 Débutant → programme minimal
+────────────────────────────────
+But
+— Afficher du texte. Vérifier que la toolchain fonctionne.
+
+Code (src/main.vitl)
+  module app.main
+  import std.io
+
+  fn main() -> i32 {
+    std.io::println("Bonjour Vitte Light")
+    return 0
+  }
+
+Explications
+— `module app.main` : identifie le module du fichier.
+— `import std.io` : active les fonctions d’E/S console.
+— `main() -> i32` : point d’entrée, retourne un code de sortie.
+— `println(...)` : écrit sur stdout puis ajoute un saut de ligne.
+
+Exécution (VM)
+  vitl run src/main.vitl
+
+Compilation (binaire)
+  vitl build -O2 -o build/hello src/main.vitl
+  ./build/hello
+
+Sortie attendue
+  Bonjour Vitte Light
+
+Erreurs fréquentes
+— E0001 symbole inconnu : oublier `import std.io`.
+— E0002 types incompatibles : concaténer nombre + string sans `.to_string()`.
+
+Variante A — afficher une variable
+  fn main() -> i32 {
+    let n = 42
+    std.io::println("n=" + n.to_string())
+    return 0
+  }
+
+Variante B — codes d’erreur
+  fn main() -> i32 {
+    if 2 + 2 != 4 {
+      std.io::eprintln("arithmétique cassée")
+      return 1  // code d’erreur générique
+    }
+    return 0
+  }
+
+
+4.2 Intermédiaire → lire un fichier
+───────────────────────────────────
+But
+— Lire un fichier texte passé en argument. Gérer les erreurs proprement.
+
+Code (src/cat.vitl)
+  module app.cat
+  import std.{fs, io, cli, str}
+
+  fn main() -> i32 {
+    let argv = cli::args()
+    if str::len(argv) < 2 {
+      io::eprintln("usage: cat <fichier>")
+      return 2  // convention: 2 = erreur d’usage
+    }
+    let path = argv[1]
+    if !fs::exists(path) {
+      io::eprintln("introuvable: " + path)
+      return 3  // convention: 3 = I/O
+    }
+    let contenu = fs::read_to_string(path)?   // propage l’erreur I/O
+    io::print(contenu)
+    return 0
+  }
+
+Explications
+— `cli::args()` : récupère les arguments CLI sous forme de [String].
+— `str::len(argv)` : taille. On exige au moins 2 éléments (binaire + fichier).
+— `fs::exists(path)` : évite une erreur inutile avant lecture.
+— `read_to_string(path)?` : renvoie Result<String, Error>. `?` propage l’erreur au runtime sous forme d’un code ≠ 0.
+— `return 2/3` : codes de sortie standardisés.
+
+Exécution
+  vitl run src/cat.vitl -- data.txt
+
+Sorties possibles
+— OK : affiche le contenu du fichier.
+— Erreur d’usage : `usage: cat <fichier>` avec code 2.
+— Fichier manquant : `introuvable: ...` avec code 3.
+
+Erreurs fréquentes
+— E2001 fichier non trouvé : oublier le test `exists`.
+— E0002 concat de String + i32 sans `.to_string()`.
+
+Variante A — lecture binaire
+  // Pour fichiers non-UTF8
+  let bytes = fs::read(path)?        // [u8]
+  io::println("taille=" + bytes.len().to_string())
+
+Variante B — chronométrer l’opération
   let t0 = std.time::now()
+  let contenu = fs::read_to_string(path)?
+  io::println("ms=" + (std.time::now() - t0).to_string())
+
+Variante C — “cat” multi-fichiers avec boucle
+  for i in 1..str::len(argv) {
+    let p = argv[i]
+    if !fs::exists(p) { io::eprintln("skip: " + p); continue }
+    io::print(fs::read_to_string(p)?)
+  }
+
+
+4.3 Pro → struct, impl, méthodes
+────────────────────────────────
+But
+— Définir un type, ajouter des méthodes, calculer une norme, tester.
+
+Code (src/geom.vitl)
+  module app.geom
+  import std.{io, math}
+
+  struct Vec2 { x: f64, y: f64 }
+
+  impl Vec2 {
+    fn norm(&self) -> f64 {
+      return (self.x*self.x + self.y*self.y).sqrt()
+    }
+    fn dot(&self, o: Vec2) -> f64 {
+      return self.x*o.x + self.y*o.y
+    }
+  }
+
+  fn main() -> i32 {
+    let v = Vec2 { x: 3.0, y: 4.0 }
+    io::println(v.norm().to_string())  // 5
+    return 0
+  }
+
+Explications
+— `struct Vec2 { x, y }` : type produit par l’utilisateur.
+— `impl Vec2 { … }` : bloc de méthodes associé à Vec2.
+— `&self` : emprunt en lecture, pas de copie complète.
+— `sqrt()` : méthode flt; import indirect via std.math.
+
+Erreurs fréquentes
+— Typo : écrire `self.xself.x` au lieu de `self.x*self.x`.
+— Oublier `import std.math` si l’impl demande des fonctions flottantes.
+
+Tests intégrés
+  test "norm classique 3-4-5" {
+    let v = Vec2 { x:3.0, y:4.0 }
+    assert(v.norm() == 5.0)
+  }
+  test "dot produit orthogonal" {
+    let a = Vec2 { x:1.0, y:0.0 }
+    let b = Vec2 { x:0.0, y:1.0 }
+    assert(a.dot(b) == 0.0)
+  }
+
+Variante A — parsing CLI vers f64
+  import std.{cli, str}
+  fn parse_f64(s: str) -> Result<f64, str> { return str::to_float(s) }
+  fn main() -> i32 {
+    let a = cli::args()
+    if str::len(a) != 3 { io::eprintln("usage: geom <x> <y>"); return 2 }
+    let x = parse_f64(a[1])?    // ? propage une Err("…")
+    let y = parse_f64(a[2])?
+    let v = Vec2 { x:x, y:y }
+    io::println(v.norm().to_string())
+    return 0
+  }
+
+Variante B — mini-bench
+  fn bench(n: i32) -> i32 {
+    let mut acc:f64 = 0.0
+    let base = Vec2 { x:1.234, y:5.678 }
+    for i in 0..n {
+      let v = Vec2 { x: base.x + (i as f64), y: base.y - (i as f64) }
+      acc = acc + v.norm()
+    }
+    // utiliser acc pour éviter l’élimination par l’optimiseur
+    std.io::println("acc=" + acc.to_string())
+    return 0
+  }
+
+  fn main() -> i32 {
+    let t0 = std.time::now()
+    _ = bench(100000)
+    std.io::println("ms=" + (std.time::now()-t0).to_string())
+    return 0
+  }
+
+
+4.4 Bonnes pratiques transverses
+────────────────────────────────
+Style
+— `module` en tête, imports regroupés.
+— snake_case pour fonctions/variables; CamelCase pour types.
+— Types explicites pour API publiques.
+
+Erreurs et robustesse
+— `?` pour propager les erreurs I/O et parsing.
+— Codes de sortie standard : 0 OK, 1 panic, 2 usage, 3 I/O, 4 FFI.
+
+Organisation
+— Un fichier = un module; découper tôt si le fichier grossit.
+— Tests en fin de fichier, liés aux fonctions du module.
+
+Perf
+— Utiliser `std.time::now()` pour mesurer.
+— Éviter les copies inutiles grâce aux slices `[T]`.
+— Pré-allouer avec `std.vec::with_capacity` si la taille est connue.
+
+Sécurité
+— Pas d’`unsafe` dans ces exemples; réserver `unsafe` au FFI.
+— Toujours convertir les chaînes en `CString` avant d’appeler du C.
+
+Raccourcis utiles
+— Formatage auto : `vitl fmt src/`
+— Lint : `vitl check src/`
+— Tests : `vitl test`
+— IR lisible : `vitl build --emit-ir -o /dev/null src/geom.vitl`
+
+
+──────────────────────────────────────────────
+
+5) MÉMOIRE ET SÉCURITÉ — GUIDE DÉTAILLÉ
+────────────────────────────────────────
+Objectif
+— Expliquer comment la mémoire est gérée dans Vitte Light (VITL).
+— Montrer les avantages du modèle choisi et les limites.
+— Donner des stratégies adaptées à chaque niveau d’expérience.
+
+────────────────────────────────────────
+5.1 Modèle mémoire en mode sûr
+──────────────────────────────
+— VITL ne possède pas de garbage collector complexe.
+— La gestion est assurée par **références comptées** (Rc<T>).
+— Quand le compteur de références tombe à zéro, l’objet est libéré immédiatement.
+— Pas de pause GC, pas de collecte asynchrone → comportement prévisible.
+
+Exemple :
+  let a = Rc<int>::new(42)
+  let b = a.clone()        // compteur fort = 2
+  a.drop()                 // compteur fort = 1
+  b.drop()                 // compteur fort = 0 → libération immédiate
+
+Avantages
+— Simplicité : pas de `malloc`/`free` manuel pour l’utilisateur.
+— Déterministe : pas de latence due à un GC qui s’exécute en arrière-plan.
+— Sécurité : la mémoire est libérée dès qu’elle n’est plus accessible.
+
+Limites
+— Les cycles de références (A→B→A) ne sont pas libérés automatiquement.
+— À éviter en structurant vos données avec Rc/Weak.
+
+────────────────────────────────────────
+5.2 Immutabilité et mutabilité
+──────────────────────────────
+— `str` est **immuable** (chaîne littérale ou constante).
+— Pour une chaîne modifiable, utiliser `String` :
+    let mut s = String::from("abc")
+    s.push("d")  // devient "abcd"
+
+— Règle générale :
+  - Immuable par défaut.
+  - Ajouter `mut` uniquement quand nécessaire.
+
+Avantages
+— Facilite le raisonnement : une valeur immuable ne change pas dans une autre partie du code.
+— Réduit les bugs liés aux effets de bord.
+
+────────────────────────────────────────
+5.3 Collections et slices
+────────────────────────
+— Les **slices** `[T]` sont des vues sur un tableau ou un vecteur :
+  Elles permettent de parcourir ou de lire sans recopier les données.
+
+Exemple :
+  let v:[i32] = [1,2,3,4]
+  for x in &v { io::println(x.to_string()) }
+
+— Les vecteurs dynamiques (`std.vec`) allouent sur le tas et grandissent au besoin.
+— Toujours utiliser `vec::with_capacity` si vous connaissez la taille prévue.
+
+────────────────────────────────────────
+5.4 Mode unsafe et pointeurs bruts
+──────────────────────────────────
+— Le mot-clé `unsafe` permet d’utiliser des pointeurs C (*T, *mut T).
+— À réserver aux appels FFI et aux cas bas niveau où Rc ne suffit pas.
+— Dans un bloc unsafe, vous assumez :
+  - Validité du pointeur.
+  - Durée de vie correcte de l’objet.
+  - Alignement mémoire conforme.
+
+Exemple minimal FFI :
+  extern "C" { fn puts(msg:*const char)->i32 }
+  let cstr = std.c::CString::from_str("hi\n")?
+  unsafe { puts(cstr.as_ptr()) }
+
+Bonne pratique
+— Encapsuler les appels `unsafe` dans une fonction VITL sûre, pour isoler le risque.
+
+────────────────────────────────────────
+5.5 Débutant, intermédiaire, pro
+──────────────────────────────────
+Débutant
+— Pas besoin de `free()`, Rc s’occupe de tout.
+— Utilisez `String` si vous devez modifier une chaîne.
+— Évitez tout `unsafe`.
+
+Intermédiaire
+— Apprenez à utiliser Rc/Weak pour éviter les cycles.
+— Utilisez les slices `[T]` pour passer des vues sur des données sans recopier.
+— Familiarisez-vous avec la différence entre `str` et `String`.
+
+Pro
+— Combinez Rc avec des pointeurs faibles (Weak) pour des graphes complexes.
+— Exploitez le FFI en encapsulant soigneusement le code `unsafe`.
+— Si besoin, utilisez des allocateurs personnalisés côté C et liez-les via FFI.
+
+────────────────────────────────────────
+5.6 Erreurs courantes à éviter
+──────────────────────────────
+— Créer des cycles de références Rc → fuite mémoire silencieuse.
+— Passer une String VITL temporaire directement au C → pointeur dangling.
+— Oublier `mut` sur une variable qui doit être modifiée → erreur de compilation.
+— Utiliser `unsafe` sans encapsulation → propagation de bugs difficiles à tracer.
+
+────────────────────────────────────────
+5.7 Récapitulatif
+─────────────────
+✓ Gestion sûre et déterministe via Rc/Weak.  
+✓ Pas de GC, pas de `malloc`/`free` manuel côté VITL.  
+✓ str immuable, String mutable.  
+✓ Slices pour éviter les copies inutiles.  
+✓ unsafe réservé aux experts pour FFI/pointeurs.  
+
+
+──────────────────────────────────────────────
+
+6) GESTION DES ERREURS
+──────────────────────
+Type standard : `Result<T, E>`  
+- `Ok(T)` → succès avec valeur
+- `Err(E)` → erreur avec info
+
+Propagation automatique avec `?` :
+let contenu = fs::read_to_string("config.txt")?
+
+yaml
+Copier le code
+
+Gestion explicite :
+match fs::read_to_string("config.txt") {
+Result::Ok(txt) => println(txt),
+Result::Err(e) => eprintln(e)
+}
+
+scss
+Copier le code
+
+`panic("msg")` → erreur irrécupérable, arrêt du programme.
+
+──────────────────────────────────────────────
+
+7) INTEROPÉRABILITÉ C (FFI) — GUIDE AVANCÉ
+───────────────────────────────────────────
+But
+— Appeler du code C depuis Vitte Light (VITL) en sécurité.
+— Définir un « shim C » propre et portable.
+— Gérer chaînes, buffers, erreurs, et l’édition de liens.
+
+Principes
+— ABI supportée : C uniquement.
+— Toute interaction mémoire non vérifiée est `unsafe`.
+— Réduire la surface `unsafe` au strict minimum.
+— Toujours documenter qui alloue et qui libère.
+
+7.1 Déclaration et appel minimal
+────────────────────────────────
+Déclarer une fonction C exposée :
+  extern "C" { fn puts(msg: *const char) -> i32 }
+
+Construire une CString et appeler :
+  let cstr = std.c::CString::from_str("Hello C!\n")?
+  unsafe { _ = puts(cstr.as_ptr()) }
+
+Lien à la lib C standard (exemple) :
+  vitl build -O2 -L libs -lc -o build/app src/main.vitl
+
+Notes
+— `CString::from_str` échoue si le texte contient un octet nul `\0`.
+— `puts` attend une chaîne C null-terminée. Ne jamais passer `str` brut.
+
+7.2 Chaînes et ownership
+────────────────────────
+Entrée VITL → C :
+— Convertir avec `CString::from_str`.
+— Conserver la CString vivante pendant tout l’appel C (durée de vie).
+
+Retour C → VITL :
+— Si la lib C **renvoie** `const char*` pointant sur un buffer interne,
+  copier immédiatement côté VITL et **ne pas** libérer côté VITL.
+— Si la lib C **alloue** et te transfère la propriété (ex: `char*` via malloc),
+  convertir en String puis libérer via `c::free(ptr)` si c’est ton contrat.
+
+Pattern de contrat (recommandé) côté C :
+— Fournir des paires `create/destroy`, `dup/free`, et préciser l’allocateur.
+
+7.3 Buffers binaires et slices
+──────────────────────────────
+Passage d’un slice VITL `[u8]` vers C :
+— Passer `ptr` et `len` séparément :
+    extern "C" { fn sha256(data:*const u8, len:usize, out:*mut u8) -> i32 }
+— Créer un buffer de sortie côté VITL et passer `as_mut_ptr()` :
+    let mut out:[u8] = [0; 32]
+    unsafe { _ = sha256(input.as_ptr(), input.len(), out.as_mut_ptr()) }
+
+Règles
+— Toujours passer `len`. Ne jamais supposer qu’un buffer est null-terminé.
+— Vérifier les bornes côté VITL avant l’appel. Ne jamais dépasser `out` cap.
+
+7.4 Structs : opacité plutôt que couplage
+───────────────────────────────────────────
+Éviter d’échanger des `struct` C inline (alignement/ABI cross-platform).
+Préférer un **handle opaque** :
+
+C (shim) :
+  typedef struct Obj Obj;
+  Obj* obj_create(int cap);
+  void obj_destroy(Obj*);
+  int  obj_push(Obj*, const char* s);   // 0 ok, <0 err
+  int  obj_len(const Obj*);
+
+VITL :
+  extern "C" {
+    fn obj_create(cap:i32)->*mut void
+    fn obj_destroy(p:*mut void)->void
+    fn obj_push(p:*mut void, s:*const char)->i32
+    fn obj_len(p:*const void)->i32
+  }
+  // Convertir str→CString, wrapper en API VITL sûre.
+  // Envelopper les appels dans `unsafe { … }`.
+
+7.5 Erreurs et mapping Result
+─────────────────────────────
+Convention côté C :
+— Retour `0` = succès. `<0` = code d’erreur. `>0` = taille/compte utile.
+
+Mapping côté VITL :
+  fn c_call_ok(code:i32) -> Result<(),str> {
+    if code == 0 { return Result::Ok(()) }
+    return Result::Err("ffi: call failed")
+  }
+
+Exemple robuste :
+  let s = std.c::CString::from_str("hi")?
+  let r = unsafe { obj_push(h, s.as_ptr()) }
+  _ = c_call_ok(r)?   // propage l’erreur proprement
+
+Astuce pro
+— Centraliser les conversions (code C → err::Error) dans un module `ffi.err`.
+
+7.6 Callbacks et user_data
+──────────────────────────
+Modèle classique C :
+  typedef void (*cb_t)(const char* msg, void* user);
+  void run_with_cb(cb_t cb, void* user);
+
+VITL :
+  // On ne déclare pas directement des closures VITL vers C.
+  // Pattern : exposer côté C une table de trampolines ou un registre.
+  // C conserve `user` (opaque) et rappelle via cb_t.
+  // VITL fournit un handle `user` obtenu d’un shim C (ex: table indexée).
+
+Recommandation
+— Laisser la gestion des callbacks dans le shim C.
+— VITL envoie un identifiant opaque (`void*`/index) et reçoit des événements
+  retransformés en appels VITL par polling ou par API pull.
+
+7.7 Linking : -L, -l, rpath, static
+────────────────────────────────────
+Dossiers :
+— `-L <dir>` : où chercher les libs.
+— `-lfoo`    : lie `libfoo.so` ou `libfoo.a`.
+
+Exemples
+— Dylib partagée :
+    vitl build -O2 -L libs -lfoo -o build/app src/main.vitl
+— Statique (si dispo) :
+    vitl build -O2 -L libs -Wl,-Bstatic -lfoo -Wl,-Bdynamic -o build/app src/main.vitl
+
+Chargement à l’exécution
+— OpenBSD/Unix : variable d’env `LD_LIBRARY_PATH` ou rpath :
+    vitl build ... -Wl,-rpath,/chemin/vers/libs
+— Windows : `.dll` dans le même dossier que l’exe ou dans le `PATH`.
+
+Bonnes pratiques
+— Versionner `libs/` dans le repo pour reproductibilité (si licences OK).
+— Épingler des versions de libs et documenter le hash/commit.
+
+7.8 Cross-plateforme : tailles et ABI
+─────────────────────────────────────
+— Utiliser des types C stables (`int32_t`, `uint64_t`, `size_t`) côté C.
+— Rester cohérent côté VITL (`i32`, `u64`, `usize`).
+— Éviter les `long`/`unsigned long` (taille change entre plateformes).
+— Attention à l’alignement et à `#pragma pack` → déconseillé.
+
+7.9 Sécurité mémoire : règles d’or
+──────────────────────────────────
+— Aucune écriture hors borne dans des buffers passés à C.
+— Jamais de double free : un seul propriétaire libère.
+— Chaînes : toujours null-terminées côté C.
+— Durée de vie : ne pas garder de pointeur C vers une String VITL temporaire.
+— Sur échec FFI, remettre l’objet VITL dans un état cohérent (ou le détruire).
+
+Checklist rapide
+[ ] Qui alloue ? Qui libère ? Écrit dans la doc.  
+[ ] Les tailles sont passées séparément et validées.  
+[ ] Tous les appels `unsafe` sont encapsulés dans des fonctions sûres.  
+[ ] Codes d’erreur convertis en `Result` avec message contextuel.  
+[ ] Tests d’intégration VITL↔C (succès et erreurs).
+
+7.10 Exemple complet : wrapper « safe » autour d’une lib C
+──────────────────────────────────────────────────────────
+C (shim, libfoo) :
+  typedef struct Foo Foo;
+  Foo* foo_create(int cap);
+  void foo_destroy(Foo*);
+  int  foo_push(Foo*, const char* s);   // 0 ok, -1 err
+  int  foo_len(const Foo*);
+
+VITL (API sûre) :
+  extern "C" {
+    fn foo_create(cap:i32)->*mut void
+    fn foo_destroy(h:*mut void)->void
+    fn foo_push(h:*mut void, s:*const char)->i32
+    fn foo_len(h:*const void)->i32
+  }
+
+  struct Foo { handle:*mut void }
+
+  fn Foo::new(cap:i32) -> Result<Foo,str> {
+    let h = unsafe { foo_create(cap) }
+    if h == std.ptr::null_mut() { return Result::Err("ffi: create failed") }
+    return Result::Ok(Foo{ handle:h })
+  }
+
+  fn Foo::push(&mut self, s:str) -> Result<(),str> {
+    let cstr = std.c::CString::from_str(s)?
+    let rc = unsafe { foo_push(self.handle, cstr.as_ptr()) }
+    if rc != 0 { return Result::Err("ffi: push failed") }
+    return Result::Ok(())
+  }
+
+  fn Foo::len(&self) -> i32 {
+    return unsafe { foo_len(self.handle) }
+  }
+
+  fn Foo::close(&mut self) -> () {
+    if self.handle != std.ptr::null_mut() {
+      unsafe { foo_destroy(self.handle) }
+      self.handle = std.ptr::null_mut()
+    }
+  }
+
+  // Usage :
+  // let mut f = Foo::new(128)?
+  // _ = f.push("abc")?
+  // io::println(f.len().to_string())
+  // f.close()
+
+7.11 Stratégie d’équipe et CI
+─────────────────────────────
+— Figer l’interface C (headers) et ajouter des tests d’intégration.
+— Sur chaque MR/PR, builder le shim C et l’exécutable VITL dans CI.
+— Publier les artefacts : lib partagée + header + empreinte (sha256).
+— Documenter rpath/LD_LIBRARY_PATH et répertoires `libs/`.
+
+7.12 Quand FFI n’est pas le bon outil
+─────────────────────────────────────
+— Appels ultra-fréquents très fins → regroupes-les (batch) côté C.
+— Sérialisation lourde objet par objet → définis un format binaire compact.
+— Besoin de threads natifs → faire tourner un runtime externe via shim.
+
+Résumé
+— L’FFI C de VITL est simple et sûr si le contrat est clair.
+— Opaque handles, CString, ptr+len, Result, surface `unsafe` minimale.
+— Documenter allocation, libération, et versions de libs.
+
+
+──────────────────────────────────────────────
+
+8) STDLIB — APERÇU DÉTAILLÉ
+────────────────────────────
+But
+— Donner une vue opérationnelle des modules standard essentiels.
+— Exposer signatures usuelles, comportements, erreurs courantes.
+— Conseils selon profils: débutant, intermédiaire, pro.
+
+Convention
+— Toutes les fonctions qui touchent au système retournent Result<…>.
+— L’opérateur `?` propage l’erreur vers l’appelant.
+— Les extraits supposent: `import std.{io, fs, str, math, time, cli, vec, debug, err, c}`.
+
+
+8.1 std.io — E/S console
+────────────────────────
+API courante
+— print(x: str|String|affichable)       -> ()
+— println(x: …)                         -> ()
+— eprint(x: …)  (stderr)                -> ()
+— eprintln(x: …) (stderr)               -> ()
+
+Exemples
+  io::println("Hello")
+  io::eprintln("fatal: config manquante")
+
+Bonnes pratiques
+— Préférer `println` pour tracer les étapes clés.
+— Pour concat, convertir: `"n=" + n.to_string()`.
+
+Pièges
+— Trop de logs = bruit. En prod, centraliser les messages d’erreur.
+
+
+8.2 std.fs — Fichiers et chemins
+────────────────────────────────
+API courante
+— read_to_string(path: str)             -> Result<String, err::Error>
+— write_string(path: str, data: str)    -> Result<(), err::Error>
+— read(path: str)                       -> Result<[u8], err::Error>
+— write(path: str, bytes: [u8])         -> Result<(), err::Error>
+— exists(path: str)                     -> bool
+
+Exemples
+  let cfg = fs::read_to_string("config.toml")?
+  _ = fs::write_string("out.txt", "ok\n")?
+
+  if !fs::exists("data.bin") {
+    io::eprintln("absent: data.bin"); return 3
+  }
+
+Débutant
+— Utiliser `read_to_string` pour du texte uniquement.
+Intermédiaire
+— Pour binaire, préférer `read`/`write` en bytes.
+Pro
+— Standardiser des chemins absolus pour la prod; vérifier droits.
+
+Pièges
+— Chemins relatifs dépendants du répertoire courant.
+— Fichiers non UTF-8 → utiliser `read` puis décoder.
+
+
+8.3 std.str — Chaînes et utilitaires
+────────────────────────────────────
+API courante
+— len(s: str|String)                    -> i32
+— split(s: str, sep: char)              -> [String]
+— find(s: str, needle: str)             -> i32    // -1 si absent
+— replace(s: str, from: str, to: str)   -> String
+— to_int(s: str)                        -> Result<i64, str>
+— to_float(s: str)                      -> Result<f64, str>
+
+Exemples
+  let n = str::len("abc")                 // 3
+  let parts = str::split("a b c", ' ')
+  let idx = str::find("abc", "b")         // 1
+  let out = str::replace("a_b", "_", "-") // "a-b"
+  let v = str::to_int("42")?              // i64
+
+Bonnes pratiques
+— Vérifier les Result de parse avec `?` et un message d’erreur clair.
+— Normaliser les entrées (trim, lower/upper) avant comparaison.
+
+Pièges
+— Concat de non-strings sans `.to_string()` → E0002.
+
+
+8.4 std.math — Maths usuelles
+──────────────────────────────
+API courante
+— abs(x: num)                            -> num
+— sqrt(x: f64)                           -> f64
+— sin/cos(x: f64)                        -> f64
+— pow(x: f64, y: f64)                    -> f64
+
+Exemples
+  let d = math::sqrt(3.0*3.0 + 4.0*4.0)  // 5.0
+  let a = math::abs(-12)                 // 12
+
+Bonnes pratiques
+— Rester en `f64` pour stabilité. Convertir les entiers en amont.
+
+Pièges
+— Racine d’un négatif → NaN. Vérifier les bornes avant `sqrt`.
+
+
+8.5 std.time — Horloge et temporisation
+────────────────────────────────────────
+API courante
+— now()                                  -> i64   // ms depuis epoch
+— sleep_ms(ms: i32)                      -> ()
+
+Exemples
+  let t0 = time::now()
   heavy()
-  std.io::println((std.time::now() - t0).to_string() + " ms")
+  io::println((time::now() - t0).to_string() + " ms")
 
-──────────────────────────────────────────────────────────────────────────────
-16) LIMITES ACTUELLES (MODE LIGHT)
-  - Pas de threads natifs.
-  - GC absent; modèle Rc + scopes.
-  - Génériques limités aux containers std (selon build).
-  - FFI stable C uniquement.
+Bonnes pratiques
+— Mesurer les sections critiques pour guider l’optimisation.
+— Pour temporiser une boucle, utiliser `sleep_ms` plutôt qu’un spin.
 
-──────────────────────────────────────────────────────────────────────────────
-17) CHECKLIST PROJET
-  [ ] module app.main défini
-  [ ] main() -> i32 présent
-  [ ] imports minimaux
-  [ ] build avec -O2 ou -g suivant cible
-  [ ] tests passent: vitl test
-  [ ] binaire dans /build
+Pièges
+— Supposer un ordre total strict entre timestamps sur machines variées.
+— Dépendances temporelles dans les tests → stabiliser via fixtures.
 
-FIN.
+
+8.6 std.cli — Arguments et environnement
+────────────────────────────────────────
+API courante
+— args()                                 -> [String]
+— env(key: str)                          -> Option<String>
+— exit(code: i32)                        -> !
+
+Exemples
+  let argv = cli::args()
+  if str::len(argv) < 2 { io::eprintln("usage: app <file>"); return 2 }
+  match cli::env("HOME") {
+    Some(h) => io::println(h),
+    None => io::eprintln("HOME non défini")
+  }
+
+Bonnes pratiques
+— Valider tôt les options; retourner 2 en cas d’usage invalide.
+
+Pièges
+— Utiliser `exit` dans des libs. Réserver `exit` au binaire `app.main`.
+
+
+8.7 std.vec — Vecteurs dynamiques
+──────────────────────────────────
+API courante
+— with_capacity(n: i32)                  -> [T]
+— push(v: &mut [T], x: T)                -> ()
+— pop(v: &mut [T])                       -> Option<T>
+— len(v: [T])                            -> i32
+— get(v: [T], i: i32)                    -> Option<&T>
+
+Exemples
+  let mut v:[i32] = vec::with_capacity(16)
+  v.push(1); v.push(2)
+  for x in &v { io::println(x.to_string()) }
+  match v.pop() { Some(x) => io::println("last="+x.to_string()), None => {} }
+
+Bonnes pratiques
+— Accéder via `get(i)` si l’index peut dépasser; sinon tester `i < vec::len(v)`.
+
+Pièges
+— Hypothèses implicites sur la capacité → réserver avec `with_capacity` si connu.
+
+
+8.8 std.debug — Assertions et backtrace
+───────────────────────────────────────
+API courante
+— assert(cond: bool)                      -> ()
+— dump(x: affichable)                     -> ()   // aide au debug
+— backtrace()                             -> ()   // si -g et supporté
+
+Exemples
+  debug::assert(sum([1,2,3]) == 6)
+  debug::dump("state=INIT")
+
+Bonnes pratiques
+— Assertions pour invariants internes; messages clairs à l’échec.
+— Activer `-g` en debug pour des traces exploitables.
+
+Pièges
+— Laisser des `dump` verbeux en prod. Garder les traces essentielles.
+
+
+8.9 std.err — Erreurs canoniques
+─────────────────────────────────
+Concept
+— `err::Error` rassemble des informations d’échec (catégorie, message, contexte).
+— La stdlib retourne souvent `Result<T, err::Error>`.
+
+Motifs communs
+— I/O: chemins, droits, formats.
+— FFI: codes retour négatifs, pointeurs invalides.
+
+Bonnes pratiques
+— Enrichir l’erreur avec contexte applicatif avant de la remonter.
+— Normaliser les codes de sortie (0 OK, 1 panic, 2 usage, 3 I/O, 4 FFI).
+
+Pièges
+— Déguiser un panic en `Err` ou inversement. Séparer fatal/récupérable.
+
+
+8.10 std.c — Pont C et mémoire bas niveau
+──────────────────────────────────────────
+API courante
+— CString::from_str(s: str)              -> Result<CString, str>
+— malloc(size: usize)                    -> *mut u8        // unsafe
+— free(ptr: *mut u8)                     -> ()             // unsafe
+
+Interop
+— Déclarer:
+    extern "C" { fn puts(msg:*const char) -> i32 }
+— Appeler:
+    let cmsg = c::CString::from_str("Hello\n")?
+    unsafe { _ = puts(cmsg.as_ptr()) }
+
+Bonnes pratiques
+— Réduire la surface `unsafe` au strict minimum.
+— Documenter qui alloue/libère chaque buffer.
+— Pour strings, toujours passer par `CString::from_str`.
+
+Pièges
+— Passer un `str` non null-terminé côté C.
+— Oublier `free` sur mémoire allouée côté C quand c’est votre responsabilité.
+
+
+8.11 Patterns composés — recettes rapides
+──────────────────────────────────────────
+Lecture fichier + parse int avec erreurs explicites
+  fn load_threshold(path: str) -> Result<i64, err::Error> {
+      let s = fs::read_to_string(path)?
+      match str::to_int(str::replace(s, "\n", "")) {
+          Result::Ok(v) => return Result::Ok(v),
+          Result::Err(_) => return Result::Err(err::Error::new("parse int échoué")),
+      }
+  }
+
+Timer simple autour d’une fonction
+  fn timed<F>(label: str, f: F) -> ()
+  where F: fn()->()
+  {
+      let t0 = time::now()
+      f()
+      io::println(label + ": " + (time::now()-t0).to_string() + " ms")
+  }
+
+CLI robuste (usage + codes de sortie)
+  fn main() -> i32 {
+      let a = cli::args()
+      if str::len(a) < 2 {
+          io::eprintln("usage: app <input>")
+          return 2
+      }
+      if !fs::exists(a[1]) {
+          io::eprintln("E2001: introuvable → " + a[1])
+          return 3
+      }
+      // …
+      return 0
+  }
+
+
+8.12 Conseils par niveau
+────────────────────────
+Débutant
+— Commencer avec io/fs/str/cli uniquement.
+— Toujours vérifier `exists` avant `read_to_string`.
+
+Intermédiaire
+— Structurer les erreurs avec `Result` et messages utiles.
+— Mesurer avec `time::now()` pour cibler l’optimisation.
+
+Pro
+— Envelopper les APIs C via `std.c` avec un shim C stable.
+— Centraliser la gestion d’erreurs `err::Error` + mapping vers codes de sortie.
+— Garder un niveau de logs cohérent et mesuré.
+
+
+──────────────────────────────────────────────
+9) STYLE ET BONNES PRATIQUES — GUIDE DÉTAILLÉ
+─────────────────────────────────────────────
+
+But
+— Donner une cohérence à tous les projets Vitte Light.
+— Aider les débutants à écrire du code lisible dès le départ.
+— Permettre aux intermédiaires de maintenir des bases de code claires.
+— Donner aux pros un style stable, compatible avec l’outillage (fmt, lint).
+
+─────────────────────────────────────────────
+9.1 Structure générale des fichiers
+───────────────────────────────────
+1) Toujours commencer par le `module` :
+   — C’est la “carte d’identité” du fichier.
+   — Exemple : fichier `src/math/linear.vitl` → `module app.math.linear`
+
+2) Grouper immédiatement les `import` :
+   — Tous les imports en bloc, sans code entre eux.
+   — Les regrouper par hiérarchie.
+   — Exemple :
+     ```
+     module app.main
+     import std.{io, fs}
+     import app.math.linear
+     ```
+
+3) Code du module ensuite :
+   — Constantes
+   — Types (struct, enum)
+   — Implémentations
+   — Fonctions
+   — Tests
+
+─────────────────────────────────────────────
+9.2 Nommage (variables, fonctions, types)
+─────────────────────────────────────────────
+Convention :
+— snake_case → variables, fonctions locales, noms de fichiers.
+— CamelCase → structs, enums, modules publics.
+
+Exemples :
+  let user_name = "Alice"
+  fn compute_area(w:i32, h:i32) -> i32 { return w*h }
+
+  struct Rectangle { width:i32, height:i32 }
+  enum Status { Ok, Failed }
+
+Pourquoi ?
+— snake_case : lisible et courant dans la majorité des langages modernes.
+— CamelCase : met en évidence les types et les concepts de haut niveau.
+
+─────────────────────────────────────────────
+9.3 Constantes et immutabilité
+─────────────────────────────────────────────
+— Toujours utiliser `const` pour les valeurs fixes :
+
+
+
+──────────────────────────────────────────────
+
+10) CONSEILS PAR NIVEAU
+───────────────────────
+Débutant :
+- Utilisez `println` pour voir vos résultats.
+- Commencez par des programmes courts (< 50 lignes).
+- Explorez `vitl fmt` pour apprendre le style standard.
+
+Intermédiaire :
+- Utilisez `test` pour vérifier vos fonctions.
+- Manipulez fichiers avec `std.fs`.
+- Maîtrisez `?` pour simplifier le code d’erreurs.
+
+Pro :
+- Intégrez des libs C via FFI.
+- Activez optimisations `-O3`.
+- Explorez `--emit-ir` pour analyser votre code.
+- Combinez VITL avec CI/CD (Makefile, CMake, GitHub Actions).
+
+──────────────────────────────────────────────
+
+11) LIMITES (VERSION LIGHT) — VERSION DÉTAILLÉE
+───────────────────────────────────────────────
+But
+— Clarifier ce qui n’existe pas encore dans Vitte Light (VITL), pourquoi, et comment contourner proprement.
+— Donner des recettes adaptées aux débutants, intermédiaires, pros.
+
+Résumé court
+— Pas de threads natifs.
+— Pas de GC complet (seulement Rc/Weak).
+— Génériques partiels uniquement.
+— FFI limité au C (ABI C).
+
+───────────────────────────────────────────────
+11.1 Pas de threads natifs
+──────────────────────────
+Ce que cela signifie
+— Aucune API VITL pour créer des threads. Pas de synchronisation (mutex, condvar) dans la stdlib VITL.
+
+Conséquences
+— Pas de parallélisme CPU intra-processus directement en VITL.
+— Les tâches concurrentes doivent être séquencées ou externalisées.
+
+Stratégies de contournement
+Débutant
+— Sérialiser le travail : découper en étapes, mesurer, optimiser l’algorithme.
+— Utiliser des fichiers temporaires ou des pipes simples pour enchaîner des outils externes (exécutés via le shell/OS).
+
+Intermédiaire
+— **Multi-processus** via FFI C (en écrivant un petit shim C qui fork/exec) et communication par *stdin/stdout* (pipes) ou fichiers.
+— **Pipelines** : lancer plusieurs instances du binaire VITL et répartir les lots de données.
+
+Pro
+— Encapsuler un runtime de threads externe (C, Rust, Go… exposé en C ABI) et appeler ses fonctions via FFI.
+— Choisir le bon modèle : *fan-out/fan-in* avec orchestration dans un parent VITL, chaque worker = process natif externe.
+— Limiter la granularité : tâches “grosses” pour amortir le coût IPC.
+
+Antipatterns
+— Simuler des “threads” avec boucles agressives et I/O bloquantes → gaspillage CPU.
+— Multiplier les processus sans contrôle de ressources → contention disque/mémoire.
+
+Checklist
+[ ] Avez-vous réellement besoin de parallélisme ?  
+[ ] Les parties lourdes sont-elles externalisables dans un binaire C/Rust appelé par VITL ?  
+[ ] Les canaux de communication sont-ils bornés et robustes aux erreurs/temps morts ?  
+
+───────────────────────────────────────────────
+11.2 Pas de GC complet (seulement Rc/Weak)
+────────────────────────────────────────────
+Ce que cela signifie
+— Gestion mémoire sûre par **références comptées** (Rc<T>) et références faibles (Weak<T>).
+— Pas de ramasse-miettes tracing. Pas de déplacement automatique d’objets. Pas de collecte de cycles automatique.
+
+Conséquences
+— Les cycles forts (A → B → A) **ne sont pas libérés** automatiquement.
+— Les performances sont prévisibles (pas de pause GC), mais l’architecture doit éviter les cycles.
+
+Stratégies de conception
+Débutant
+— Préférer des structures arborescentes sans références en arrière.
+— Passer des données par valeur quand c’est petit et fréquent (i32, f64…).
+
+Intermédiaire
+— Utiliser **Weak** pour les pointeurs “retour” (parent) et **Rc** pour les pointeurs “avant” (enfants).
+— Documenter la topologie (qui possède quoi). Une seule direction en **fort**, l’autre en **faible**.
+
+Pro
+— Introduire des *zones de vie* et des frontières claires entre propriétaires et observateurs.
+— Auditer régulièrement (revue de code) les graphes d’objets susceptibles de former des cycles.
+— Si nécessaire, encapsuler un allocateur/arena côté C via FFI pour des patterns haute fréquence (pools, slab).
+
+Exemple (rupture de cycle)
+Mauvais (cycle fort):
+  // A::child -> Rc<B>, B::parent -> Rc<A>  (cycle)
+Correct (parent faible):
+  // A::child -> Rc<B>, B::parent -> Weak<A>
+
+Checklist
+[ ] Les relations parents/enfants évitent-elles les cycles forts ?  
+[ ] Les valeurs volumineuses sont-elles partagées via Rc et lues majoritairement ?  
+[ ] Les buffers temporaires élevés en fréquence sont-ils réutilisés (éviter l’allocation répétée) ?  
+
+───────────────────────────────────────────────
+11.3 Génériques partiels uniquement
+──────────────────────────────────
+Ce que cela signifie
+— Les types/génériques existent de façon limitée (principalement dans la stdlib).
+— Moins de métaprogrammation que dans Vitte “complet” ou Rust.
+
+Conséquences
+— API “générique” parfois moins flexible.
+— Possibles duplications de code quand les types varient beaucoup.
+
+Stratégies de conception
+Débutant
+— Commencer avec des types concrets (i32, f64, String). Éviter d’abstraire trop tôt.
+— Favoriser des fonctions simples et spécialisées.
+
+Intermédiaire
+— Factoriser par **interfaces de données** (formats texte, lignes, enregistrements) au lieu de viser la généricité type-paramétrée.
+— Utiliser des adaptateurs minces : convertisseurs `to_string()`, `parse()` côté std.str.
+
+Pro
+— Déporter la généricité “lourde” dans une lib C/Rust accessible via FFI C (sur quelques points chauds seulement).
+— Stabiliser vos **types de domaine** (DTO) et isoler les conversions aux frontières de module.
+— Intégrer des tests de non-régression lors des changements de type.
+
+Checklist
+[ ] Les fonctions publiques ont-elles des signatures **stables** et explicites ?  
+[ ] Les conversions de types sont-elles centralisées et testées ?  
+[ ] Les points nécessitant de la généricité forte sont-ils délégués à FFI si critique ?  
+
+───────────────────────────────────────────────
+11.4 FFI limité au C (ABI C)
+────────────────────────────
+Ce que cela signifie
+— Seule l’interface binaire C est supportée nativement.
+— C++/Rust/Go/etc. doivent exposer un **shim C** (`extern "C"`) pour être appelés.
+
+Conséquences
+— Pas de passage direct d’objets complexes non-C.
+— Convention d’appel et représentation mémoire = C.
+
+Stratégies d’intégration
+Débutant
+— S’en tenir aux appels simples : fonctions C pures, entrées/sorties primitives, buffers.
+— Toujours construire les chaînes avec `std.c::CString::from_str` avant de passer au C.
+
+Intermédiaire
+— Écrire un **shim C** propre : API plate, types opaques (`void*` + fonctions d’accès), fonctions `create()/destroy()`.
+— Vérifier les codes retour et convertir vers `Result`.
+
+Pro
+— Définir une **ABI stable** (semver) côté C, tests d’intégration croisés (VITL ↔ C).
+— Mesurer l’overhead d’appels FFI et grouper les opérations pour amortir le coût.
+— Gérer explicitement l’allocation/désallocation croisée (qui possède le buffer ? qui le libère ?).
+
+Exemple de pattern FFI
+C (shim):
+  struct Obj;
+  Obj* obj_create(int cap);
+  void  obj_destroy(Obj*);
+  int   obj_push(Obj*, const char* s);  // 0=OK, <0=err
+  int   obj_len(const Obj*);
+
+VITL:
+  extern "C" {
+    fn obj_create(cap:i32)->*mut void
+    fn obj_destroy(p:*mut void)->void
+    fn obj_push(p:*mut void, s:*const char)->i32
+    fn obj_len(p:*const void)->i32
+  }
+  // Construire CString, appeler dans unsafe, vérifier codes retour.
+
+Checklist
+[ ] Le shim expose-t-il uniquement des types C stables (int, double, void*, char*) ?  
+[ ] Les responsabilités d’allocation/libération sont-elles documentées ?  
+[ ] Chaque appel renvoie-t-il un code d’erreur testable, converti en `Result` côté VITL ?  
+
+───────────────────────────────────────────────
+11.5 Décider quand “sortir” des limites
+─────────────────────────────────────────────
+Règle pratique
+— Si la fonctionnalité manque et que l’**algorithme** suffit à compenser → rester 100% VITL.
+— Si les contraintes sont structurelles (threads, généricité lourde, GC) → **isoler** la partie critique dans une lib C/Rust avec shim C et piloter depuis VITL.
+
+Matrice rapide
+— Performance CPU brute → déléguer le cœur à C/Rust (FFI).  
+— I/O intensif séquentiel → VITL convient, optimiser le format et les buffers.  
+— Concurrence massive → multi-processus ou runtime externe via FFI.  
+— Modèles de données dynamiques et très polymorphes → fixer des DTO stables + shims.
+
+───────────────────────────────────────────────
+11.6 Contrats de qualité autour des limites
+────────────────────────────────────────────
+— Tests : pour chaque contour, fournir au moins 1 test succès + 1 test erreur.
+— Logs : enrichir les messages d’erreur avec contexte (fichier, taille, chemin).
+— Docs : annoter les fonctions “limites” avec `///` précisant invariants et coûts.
+— Bench : garder un micro-benchmark des chemins FFI et des I/O.
+
+Fin de la section 11.
+
+
+──────────────────────────────────────────────
+
+12) CODES DE SORTIE
+────────────────────
+0 → succès  
+1 → erreur générique/panic  
+2 → erreur d’usage CLI  
+3 → erreur I/O  
+4 → erreur FFI
+
+──────────────────────────────────────────────
+11) DIAGNOSTICS COURANTS — VERSION DÉTAILLÉE
+────────────────────────────────────────────
+
+But
+— Donner pour chaque code : symptôme, causes probables, correctifs, exemples.
+— Cible débutants → comprendre le message. Intermédiaires → corriger vite. Pros → outillage.
+
+Outils utiles
+— Lint :        vitl check src/
+— Build debug : vitl build -g -O0 -o build/app src/main.vitl
+— IR/BC :       vitl build --emit-ir     | vitl build --emit-bytecode
+— Traces :      std.debug::backtrace()   | panic("msg")
+— Recherche :   vitl doc src/ -o build/docs.txt
+
+Notation
+— « Mauvais » = exemple fautif. « Correct » = correction minimale.
+
+
+E0001 : symbole inconnu
+───────────────────────
+Symptôme
+— Le compilateur ne trouve pas une fonction, un type, un module ou une constante.
+
+Causes fréquentes
+— Import manquant ou chemin de module incorrect.
+— Typo dans le nom (majuscules/minuscules).
+— Déplacement de fichier sans mise à jour de `module` en tête.
+— API renommée lors d’une refactorisation.
+
+Correctifs standard
+— Ajouter l’import précis ou corriger le chemin.
+— Vérifier que `module` en tête correspond au chemin disque.
+— Lancer `vitl fmt` pour regrouper et stabiliser les imports.
+
+Exemples
+Mauvais:
+  module app.main
+  fn main()->i32 {
+    std.io::pritnln("hi")   // typo
+    return 0
+  }
+
+Correct:
+  module app.main
+  import std.io
+  fn main()->i32 {
+    std.io::println("hi")
+    return 0
+  }
+
+Astuce pro
+— Préférer `import std.{io, fs}` pour expliciter le périmètre.
+— `vitl check` pointe la ligne et la colonne exactes.
+
+
+E0002 : types incompatibles
+───────────────────────────
+Symptôme
+— Une expression du type A est passée là où B est attendu.
+
+Causes fréquentes
+— Addition mélangeant `i32` et `f64`.
+— Appel d’API avec paramètre de type attendu différent.
+— Comparaison stricte entre types non convertibles.
+
+Correctifs standard
+— Ajouter un cast explicite `as` quand la perte d’info est acceptée.
+— Adapter la signature de la fonction ou l’appelant pour unifier les types.
+— Introduire une conversion préalable (ex. `to_string()`).
+
+Exemples
+Mauvais:
+  let n:i32 = 3
+  let x:f64 = 0.5
+  let y = n + x     // E0002
+
+Correct (1 — cast local):
+  let n:i32 = 3
+  let x:f64 = 0.5
+  let y = (n as f64) + x
+
+Correct (2 — normaliser l amont):
+  let n:f64 = 3.0
+  let x:f64 = 0.5
+  let y = n + x
+
+Autres patterns
+— Chaînes:
+    std.io::println("n=" + n)        // E0002
+    std.io::println("n=" + n.to_string())   // OK
+
+Astuce pro
+— Stabiliser les types aux frontières d’API publiques (types explicites).
+— `vitl check` repère aussi les conversions implicites dangereuses.
+
+
+E0003 : variable non initialisée
+────────────────────────────────
+Symptôme
+— Utilisation d’une variable qui n’a pas reçu de valeur sur tous les chemins.
+
+Causes fréquentes
+— Déclaration séparée de l’initialisation.
+— Chemin `if/else` non exhaustif.
+— Retour prématuré avant affectation.
+
+Correctifs standard
+— Initialiser à la déclaration.
+— Rendre les branches exhaustives.
+— Restructurer en `match` pour couvrir tous les cas.
+
+Exemples
+Mauvais:
+  let mut acc:i32
+  if cond { acc = 1 }
+  // cond=false → acc non assignée
+  std.io::println(acc.to_string())   // E0003
+
+Correct:
+  let mut acc:i32 = 0
+  if cond { acc = 1 }
+  std.io::println(acc.to_string())
+
+Autre:
+  let x:i32
+  if a { x = 1 } else { x = 2 }
+  // ici OK car exhaustif
+
+Astuce pro
+— Éviter les « variables sentinelles »; préférer un `match` retournant une valeur.
+
+
+E1001 : appel FFI non-safe hors bloc unsafe
+────────────────────────────────────────────
+Symptôme
+— Appel d’une fonction C ou manipulation de pointeurs bruts sans `unsafe`.
+
+Causes fréquentes
+— Oubli du bloc `unsafe { ... }`.
+— Conversion de chaîne en `CString` non vérifiée.
+— Passage d’un pointeur invalide à une API C.
+
+Correctifs standard
+— Envelopper *uniquement* l’appel risqué dans `unsafe`.
+— Construire les `CString` via `std.c::CString::from_str`.
+— Assurer la durée de vie des buffers passés au C.
+
+Exemples
+Mauvais:
+  extern "C" { fn puts(msg:*const char)->i32 }
+  fn main()->i32 {
+    let s = std.c::CString::from_str("Hi\n")
+    puts(s.as_ptr())          // E1001
+    return 0
+  }
+
+Correct:
+  extern "C" { fn puts(msg:*const char)->i32 }
+  fn main()->i32 {
+    let s = std.c::CString::from_str("Hi\n")
+    unsafe { _ = puts(s.as_ptr()) }
+    return 0
+  }
+
+Astuce pro
+— Réduire la surface `unsafe` au strict minimum.
+— Valider les tailles et null-terminators côté VITL avant l’appel.
+
+
+E2001 : fichier introuvable (I/O)
+─────────────────────────────────
+Symptôme
+— Échec d’ouverture/lecture d’un fichier par la stdlib (erreur au runtime).
+
+Causes fréquentes
+— Chemin relatif interprété depuis un répertoire inattendu.
+— Fichier non copié ou supprimé.
+— Droits insuffisants, montage absent.
+
+Correctifs standard
+— Tester l’existence avant lecture.
+— Utiliser des chemins absolus pour les ressources système.
+— Gérer l’erreur avec `Result` et message contextuel.
+
+Exemples
+Mauvais:
+  let txt = std.fs::read_to_string("data/config.txt")?   // E2001
+
+Correct:
+  let path = "data/config.txt"
+  if !std.fs::exists(path) {
+    std.io::eprintln("config manquante: " + path)
+    return 3
+  }
+  let txt = std.fs::read_to_string(path)?
+
+
+Annexe A — Diagnostics supplémentaires courants
+───────────────────────────────────────────────
+E0100 : variable non utilisée
+— Contexte: le code compile mais une variable n est jamais lue.
+— Correction: supprimer la variable, ou prefixer `_var` pour marquer volontaire.
+
+E0101 : code inatteignable
+— Contexte: instructions après `return` ou après un `match` exhaustif.
+— Correction: retirer la portion morte ou factoriser les branches.
+
+E0201 : division par zéro détectable
+— Contexte: `x / 0` littéral connu au compile-time.
+— Correction: vérifier dénominateur, valider en amont.
+
+E0301 : dépassement d’index (runtime)
+— Contexte: `v[i]` hors bornes.
+— Correction: tester `i < v.len()`, ou utiliser `get(i)` qui retourne `Option`.
+
+E0401 : pattern `match` non exhaustif
+— Contexte: manque un cas, surtout avec `enum`.
+— Correction: ajouter `_ => {...}` ou toutes les variantes.
+
+E0501 : conflit mutabilité simple
+— Contexte: tentative d’écrire dans une donnée non `mut`.
+— Correction: déclarer `let mut x` ou cloner/retourner une nouvelle valeur.
+
+E0601 : format de chaîne invalide
+— Contexte: concat de types non-string sans `to_string()`.
+— Correction: convertir avant concaténation.
+
+E0701 : échec FFI (résultat négatif)
+— Contexte: fonction C renvoie code erreur.
+— Correction: vérifier le code retour, convertir en `Result::Err(...)` côté VITL.
+
+E0801 : UTF-8 invalide lors d une lecture texte
+— Contexte: contenu binaire lu via `read_to_string`.
+— Correction: utiliser `std.fs::read` (bytes) puis décoder conditionnellement.
+
+
+Annexe B — Stratégie de triage (checklist rapide)
+──────────────────────────────────────────────────
+1) Lire le message complet et la ligne ciblée.
+2) Lancer `vitl check` pour lints supplémentaires.
+3) Si import/symbole: vérifier `module` et `import`.
+4) Si types: normaliser les types en amont, cast explicite si nécessaire.
+5) Si non initialisé: initialiser à la déclaration ou rendre les branches exhaustives.
+6) Si FFI: entourer par `unsafe`, valider les pointeurs et durées de vie.
+7) Si I/O: controler `std.fs::exists`, chemins absolus, droits.
+8) Recompiler avec `-g` et activer `std.debug::backtrace()` en cas de crash.
+9) Ajouter des `test` minimaux pour reproduire le bug.
+10) Documenter la cause et le correctif en commentaire `///` si API publique.
+
+
+Annexe C — Exemples de messages enrichis côté application
+──────────────────────────────────────────────────────────
+— I/O robuste:
+  let path = argv[1]
+  if !std.fs::exists(path) {
+    std.io::eprintln("E2001: fichier introuvable → " + path)
+    std.io::eprintln("Astuce: lancer depuis la racine du projet ou passer un chemin absolu.")
+    return 3
+  }
+
+— FFI robuste:
+  let msg = std.c::CString::from_str("ok\n")
+  if msg.is_err() {
+    return Result::Err("E0601: CString invalide (caractère nul)")
+  }
+  unsafe { _ = puts(msg.unwrap().as_ptr()) }
+
+
+Annexe D — Bonnes pratiques pour éviter les diagnostics
+────────────────────────────────────────────────────────
+— Imports précis et groupés; `vitl fmt` après chaque session.
+— Types explicites aux frontières d’API (fonctions `pub`).
+— Tests unitaires pour chaque module; couvrir les erreurs attendues.
+— Logs de contexte avec codes d’erreur stables (E-codes ci-dessus).
+— Limiter `unsafe` et l’isoler; documenter les invariants attendus.
+— Préférer `Option`/`Result` aux valeurs sentinelles magiques.
+— Valider l’entrée utilisateur tôt; fail fast avec message clair.
+
+Fin de la section 10.
+
+14) CHECKLIST AVANT DE LIVRER
+─────────────────────────────
+[ ] module app.main défini  
+[ ] fn main()->i32 présent  
+[ ] imports réduits au nécessaire  
+[ ] vitl test passe avec succès  
+[ ] build/app généré dans /build  
+
+──────────────────────────────────────────────
+
+─────────────────────────────────────────────

--- a/docs/doc.md
+++ b/docs/doc.md
@@ -1,1068 +1,346 @@
-<!doctype html>
-<html lang="fr">
-<head>
-<meta charset="utf-8" />
-<meta name="viewport" content="width=device-width,initial-scale=1" />
-<title>VITTE LIGHT — Guide utilisateur complet (Révision 2025-09-05)</title>
-<meta name="color-scheme" content="light dark" />
-<style>
-  :root{
-    --bg:#ffffff; --fg:#0f172a; --muted:#64748b; --card:#f8fafc;
-    --border:#e2e8f0; --accent:#2563eb; --code:#111827;
-  }
-  @media (prefers-color-scheme: dark){
-    :root{
-      --bg:#0b1020; --fg:#e8eef6; --muted:#9aa7bd; --card:#0f152a;
-      --border:#1f2a44; --accent:#60a5fa; --code:#e6edf3;
-    }
-  }
-  *{box-sizing:border-box}
-  body{
-    margin:0; background:var(--bg); color:var(--fg);
-    font:16px/1.7 system-ui,-apple-system,Segoe UI,Roboto,Inter,Arial,"Noto Sans";
-  }
-  a{ color:var(--accent); text-decoration:none }
-  a:hover{ text-decoration:underline }
-  header{
-    padding:24px; border-bottom:1px solid var(--border);
-    background:linear-gradient(180deg, rgba(99,102,241,.08), transparent);
-  }
-  .container{ max-width:1000px; margin:0 auto; padding:24px }
-  .intro{ display:flex; gap:18px; align-items:flex-end; flex-wrap:wrap }
-  h1{ margin:0; font-size:clamp(24px,3vw,36px); letter-spacing:.2px }
-  .rev{ color:var(--muted) }
-  nav.toc{
-    background:var(--card); border:1px solid var(--border); border-radius:12px;
-    padding:14px 16px; margin:20px 0 8px 0;
-  }
-  nav.toc strong{ font-size:13px; color:var(--muted); text-transform:uppercase; letter-spacing:.08em }
-  nav.toc ul{ margin:8px 0 0 0; padding:0 0 0 16px }
-  section{ margin:28px 0 }
-  h2{ margin:0 0 10px 0; padding-top:10px; border-top:1px solid var(--border) }
-  h3{ margin:18px 0 8px 0 }
-  p{ margin:.6rem 0 }
-  ul,ol{ margin:.4rem 0 .8rem 1.25rem }
-  .card{
-    background:var(--card); border:1px solid var(--border); border-radius:12px; padding:16px;
-  }
-  code{
-    font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,Monaco,monospace;
-    background:color-mix(in srgb, var(--card) 85%, transparent);
-    color:var(--code); padding:.15em .35em; border-radius:6px; border:1px solid var(--border)
-  }
-  pre{
-    margin:.75rem 0; padding:14px 16px; border-radius:12px;
-    background:var(--card); border:1px solid var(--border); overflow:auto
-  }
-  pre code{ background:transparent; border:0; padding:0; color:var(--code) }
-  hr{ border:0; border-top:1px dashed var(--border); margin:16px 0 }
-  .note{ color:var(--muted); font-size:.95rem }
-</style>
-</head>
-<body>
-  <header>
-    <div class="container intro">
-      <h1>VITTE LIGHT — Guide utilisateur complet</h1>
-      <span class="rev">Révision&nbsp;: 2025-09-05</span>
-    </div>
-  </header>
-
-  <main class="container">
-    <nav class="toc" aria-label="Table des matières">
-      <strong>Sommaire</strong>
-      <ul>
-        <li><a href="#intro">0) Introduction</a>
-          <ul>
-            <li><a href="#philosophie">0.1 Philosophie</a></li>
-            <li><a href="#pour-qui">0.2 Pour qui&nbsp;?</a></li>
-            <li><a href="#domaines">0.3 Domaines d'utilisation</a></li>
-            <li><a href="#points-forts">0.4 Points forts</a></li>
-            <li><a href="#hello">0.5 Exemple rapide</a></li>
-          </ul>
-        </li>
-        <li><a href="#structure">1) Structure de projet</a></li>
-        <li><a href="#cli">2) Outils en ligne de commande</a></li>
-        <li><a href="#syntaxe">3) Syntaxe : découverte progressive</a></li>
-        <li><a href="#exemples">4) Premiers exemples</a></li>
-        <li><a href="#memoire">5) Mémoire et sécurité</a></li>
-        <li><a href="#erreurs">6) Gestion des erreurs</a></li>
-        <li><a href="#ffi">7) Interopérabilité C (FFI)</a></li>
-        <li><a href="#stdlib">8) Stdlib — aperçu</a></li>
-        <li><a href="#style">9) Style et bonnes pratiques</a></li>
-        <li><a href="#niveaux">10) Conseils par niveau</a></li>
-        <li><a href="#limites">11) Limites (version Light)</a></li>
-        <li><a href="#codes-sortie">12) Codes de sortie</a></li>
-        <li><a href="#diagnostics">13) Diagnostics courants</a></li>
-        <li><a href="#checklist">14) Checklist avant de livrer</a></li>
-      </ul>
-    </nav>
-
-    <!-- 0) INTRO -->
-    <section id="intro">
-      <h2>0) Introduction — VITTE LIGHT</h2>
-      <p><strong>Vitte Light</strong> (abrégé <strong>VITL</strong>) est un langage minimaliste, dérivé du langage Vitte, conçu pour allier <strong>syntaxe moderne</strong>, <strong>simplicité d’usage</strong> et <strong>outillage complet</strong>. Il vise trois profils de développeurs&nbsp;: débutants, intermédiaires, professionnels.</p>
-
-      <section id="philosophie">
-        <h3>0.1 Philosophie du langage</h3>
-        <ul>
-          <li><strong>Minimalisme</strong>&nbsp;: garder un cœur réduit de fonctionnalités, faciles à apprendre.</li>
-          <li><strong>Cohérence</strong>&nbsp;: syntaxe claire, pas de règles cachées, erreurs explicites.</li>
-          <li><strong>Polyvalence</strong>&nbsp;: exécution immédiate via VM, compilation native, intégration en C.</li>
-          <li><strong>Sécurité</strong>&nbsp;: gestion mémoire déterministe (références comptées), erreurs explicites (<code>Result</code>, <code>panic</code>).</li>
-          <li><strong>Portabilité</strong>&nbsp;: fonctionne sur Linux, BSD, macOS, Windows.</li>
-        </ul>
-      </section>
-
-      <section id="pour-qui">
-        <h3>0.2 Pour qui est fait VITL&nbsp;?</h3>
-        <p><strong>Débutant</strong></p>
-        <ul>
-          <li>Découvrir la programmation avec une syntaxe simple et lisible.</li>
-          <li>Éviter la complexité (pointeurs, mémoire manuelle, GC lourd).</li>
-          <li>Apprendre progressivement&nbsp;: immutabilité, <code>Result</code>, <code>match</code>.</li>
-        </ul>
-        <p><strong>Développeur intermédiaire</strong></p>
-        <ul>
-          <li>Scripts rapides et compacts pour automatiser des tâches.</li>
-          <li>Petites applications CLI portables.</li>
-          <li>Formateur, linter et tests intégrés.</li>
-        </ul>
-        <p><strong>Professionnel</strong></p>
-        <ul>
-          <li>Compilation native optimisée (<code>-O3</code>).</li>
-          <li>FFI C stable pour réutiliser des bibliothèques existantes.</li>
-          <li>Intégration CI/CD, packaging, inspection IR/bytecode (<code>--emit-ir</code>, <code>--emit-bytecode</code>).</li>
-        </ul>
-      </section>
-
-      <section id="domaines">
-        <h3>0.3 Domaines d'utilisation</h3>
-        <ol>
-          <li><strong>Écriture rapide de scripts CLI</strong> : remplacement ciblé de Bash/Python, automatisation, parsing, texte.</li>
-          <li><strong>Compilation en exécutables natifs</strong> : binaires autonomes, distribution, embarqué, multi-plateformes.</li>
-          <li><strong>Langage embarqué (FFI C)</strong> : intégration dans des projets C, chargement de <code>.vitbc</code>, scripts extensibles.</li>
-        </ol>
-      </section>
-
-      <section id="points-forts">
-        <h3>0.4 Points forts</h3>
-        <ul>
-          <li>Syntaxe lisible et unifiée (identique à Vitte).</li>
-          <li>Gestion mémoire <code>Rc</code>/<code>Weak</code> simple et prévisible.</li>
-          <li>Erreurs explicites <code>Result</code> et propagation <code>?</code>.</li>
-          <li>Stdlib couvrant I/O, fichiers, chaînes, maths, temps, vecteurs.</li>
-          <li>Outils intégrés : <code>fmt</code>, <code>check</code>, <code>test</code>, <code>doc</code>.</li>
-          <li>Exécution directe ou compilation native optimisée.</li>
-          <li>FFI C stable et facile.</li>
-        </ul>
-      </section>
-
-      <section id="hello">
-        <h3>0.5 Exemple rapide (Hello World)</h3>
-<pre><code>module app.main
-import std.io
-
-fn main() -&gt; i32 {
-  std.io::println("Bonjour Vitte Light")
-  return 0
-}
-</code></pre>
-        <p><strong>Exécution</strong> : <code>vitl run src/main.vitl</code></p>
-        <p><strong>Compilation</strong> : <code>vitl build -O2 -o build/app src/main.vitl &amp;&amp; ./build/app</code></p>
-        <p class="note"><strong>Résumé</strong> — Débutant : apprendre sans complexité inutile · Intermédiaire : scripts compacts et portables · Pro : compilateur performant, FFI C stable, toolchain complète.</p>
-      </section>
-    </section>
-
-    <hr />
-
-    <!-- 1) STRUCTURE -->
-    <section id="structure">
-      <h2>1) Structure de projet — Guide complet</h2>
-      <p>Un projet VITL repose sur une organisation stricte des dossiers et fichiers pour faciliter navigation, compilation et intégration (CMake, Meson, CI/CD, IDE).</p>
-
-      <h3>1.1 Arborescence type minimale</h3>
-<pre><code>/src   → code source principal (.vitl)
- /libs → bibliothèques natives C/FFI (.c, .so, .dll, .a)
- /build→ binaires, artefacts intermédiaires, bytecode (.vitbc)
-
-mon_projet/
-  src/
-    main.vitl
-    util/str.vitl
-  libs/
-    mylib.c
-    mylib.a
-  build/
-    app        (binaire natif)
-    app.vitbc  (bytecode)
-</code></pre>
-
-      <h3>1.2 Convention des modules</h3>
-      <ul>
-        <li>Un fichier = un module.</li>
-        <li>Chemin disque = nom de module.</li>
-        <li>Nom en <code>snake.case</code>.</li>
-      </ul>
-<pre><code>Fichier : src/std/io.vitl
-Contenu : module std.io
-</code></pre>
-      <p>Imports clairs : <code>import std.io</code>, <code>import util.str</code>. Évite les conflits, favorise la réutilisation.</p>
-
-      <h3>1.3 Organisation recommandée</h3>
-<pre><code>/src
-  app/  → logique applicative
-  std/  → std locale/complémentaire
-  util/ → utilitaires internes
-/libs
-  externe/ → wrappers C tiers
-  interne/ → code C maison via FFI
-/build
-  debug/   → -O0 -g
-  release/ → -O3
-  docs/    → `vitl doc`
-</code></pre>
-
-      <h3>1.4 Raison d’être</h3>
-      <p>Débutant&nbsp;: lisibilité · Intermédiaire&nbsp;: séparation claire, tests faciles · Pro&nbsp;: packaging, CI/CD, FFI propre.</p>
-
-      <h3>1.5 Variantes de structure</h3>
-<pre><code>Projet simple : /src/main.vitl
-
-Projet moyen :
-  /src main.vitl  cli/args.vitl  math/geom.vitl
-  /libs fastmath.c
-
-Projet complexe :
-  /src app/main.vitl  net/http.vitl  net/tcp.vitl  core/error.vitl  config.vitl
-  /tests test_math.vitl  test_net.vitl
-  /libs/sqlite/sqlite3.c
-  /build/{debug,release}
-  /docs
-</code></pre>
-
-      <h3>1.6 Conseils pratiques</h3>
-      <ul>
-        <li><code>module chemin.nom</code> en tête de fichier, puis les <code>import</code>.</li>
-        <li><code>/src</code> pour VITL, <code>/libs</code> pour C, <code>/build</code> pour binaires.</li>
-        <li><code>/tests</code> dédié si le projet grandit.</li>
-        <li>Ne pas mélanger artefacts et sources.</li>
-      </ul>
-
-      <p class="card"><strong>Résumé</strong> — <code>/src</code> : VITL · <code>/libs</code> : FFI · <code>/build</code> : binaires/docs · Nom module = chemin · Rigueur = lisibilité/CI.</p>
-    </section>
-
-    <hr />
-
-    <!-- 2) CLI -->
-    <section id="cli">
-      <h2>2) Outils en ligne de commande — Guide complet</h2>
-      <p>Selon la distribution :</p>
-      <ul>
-        <li><strong>Binaire unique</strong> <code>vitl</code> (compilation, VM, <code>fmt</code>, <code>check</code>, <code>test</code>, <code>doc</code>).</li>
-        <li><strong>Couple</strong> <code>vitlc</code> (compilateur) + <code>vitlv</code> (VM) pour séparer build/exécution.</li>
-      </ul>
-
-      <h3>2.1 Exécution immédiate (VM/JIT)</h3>
-<pre><code>vitl run src/main.vitl
-# ou
-vitlv run src/main.vitl
-</code></pre>
-      <ul>
-        <li>Compile en bytecode puis exécute dans la VM (vérifs sécurité/syntaxe).</li>
-        <li>Idéal pour tester vite, prototyper, CI sans build.</li>
-        <li>Erreur fréquente : oublier le chemin (affiche l’aide).</li>
-      </ul>
-
-      <h3>2.2 Compilation en exécutable natif</h3>
-<pre><code>vitl build -O2 -o build/app src/main.vitl
-# ou
-vitlc -O2 -o build/app src/main.vitl
-</code></pre>
-      <ul>
-        <li>Binaire natif, autonome, rapide.</li>
-      </ul>
-
-      <h3>2.3 Outils supplémentaires</h3>
-<pre><code>vitl fmt src/             # formateur
-vitl check src/           # analyse statique
-vitl test                 # exécute les blocs `test "nom" { ... }`
-vitl doc src/ -o build/docs.txt  # documentation à partir de ///</code></pre>
-
-      <h3>2.4 Options utiles</h3>
-      <ul>
-        <li><code>-O0</code>, <code>-O1</code>, <code>-O2</code> (défaut), <code>-O3</code></li>
-        <li><code>-g</code> pour debug/backtrace</li>
-        <li><code>--emit-ir</code>, <code>--emit-bytecode</code></li>
-      </ul>
-<pre><code>vitl build -O0 -g -o build/app src/main.vitl &amp;&amp; ./build/app</code></pre>
-
-      <h3>2.5 Bonnes pratiques CLI</h3>
-      <ul>
-        <li>Débutant : <code>vitl run</code> + <code>vitl fmt</code>.</li>
-        <li>Intermédiaire : <code>vitl build -O2 -g</code> + <code>vitl check</code>.</li>
-        <li>Pro : <code>test</code>/<code>check</code> en CI, livrer <code>-O3</code>, générer la doc.</li>
-      </ul>
-
-      <h3>2.6 Erreurs fréquentes</h3>
-      <ul>
-        <li><strong>E0001</strong> fichier introuvable.</li>
-        <li><strong>Permission denied</strong> : penser à <code>chmod +x</code>.</li>
-        <li>Ordre d’options : <code>-o build/app</code> après <code>build</code>.</li>
-      </ul>
-    </section>
-
-    <hr />
-
-    <!-- 3) SYNTAXE -->
-    <section id="syntaxe">
-      <h2>3) Syntaxe : découverte progressive</h2>
-      <p><strong>But</strong> — Apprendre les briques de base de VITL, comprendre la logique, éviter les erreurs classiques.</p>
-
-      <h3>3.1 Commentaires</h3>
-      <ul>
-        <li>Ligne : <code>//</code> jusqu’à la fin de ligne.</li>
-        <li>Bloc : <code>/* ... */</code> multi-lignes.</li>
-      </ul>
-<pre><code>// commentaire
-let x = 42  // commentaire en fin de ligne
-
-/* commentaire multi-lignes */
-</code></pre>
-
-      <h3>3.2 Variables et constantes</h3>
-<pre><code>const PI: f64 = 3.14159
-let mut compteur: i32 = 0
-let message = "Salut"  // inférence: str
-
-// Erreur : variable non mutable
-let n = 0
-n = n + 1
-
-// Correct
-let mut n = 0
-n = n + 1
-</code></pre>
-
-      <h3>3.3 Fonctions</h3>
-<pre><code>fn add(a: i32, b: i32) -&gt; i32 { return a + b }
-
-// variante
-fn square(x: i32) -&gt; i32 { return x * x }
-
-// Erreur : manque le type de retour
-fn bad(x: i32) { return x * x }
-</code></pre>
-
-      <h3>3.4 Structures de contrôle</h3>
-<pre><code>if x &gt; 0 { println("positif") } else { println("non positif") }
-
-for i in 0..10 { println(i.to_string()) }  // 0..9
-for i in 0..=10 { println(i.to_string()) } // 0..10
-
-let mut n = 0
-while n &lt; 5 { println(n.to_string()); n = n + 1 }
-</code></pre>
-
-      <h3>3.5 <code>match</code> (pattern matching)</h3>
-<pre><code>match valeur {
-  0 =&gt; println("zéro"),
-  1 | 2 =&gt; println("petit"),
-  _ =&gt; println("autre"),
-}
-
-enum Status { Ok, Err(str) }
-let s = Status::Err("oops")
-match s {
-  Status::Ok =&gt; println("ok"),
-  Status::Err(msg) =&gt; println("erreur:" + msg),
-}
-</code></pre>
-
-      <h3>3.6 Types de base et littéraux</h3>
-      <ul>
-        <li>Entiers : <code>0</code>, <code>42</code>, <code>1_000</code>, <code>0xFF</code>, <code>0o755</code>, <code>0b1010</code></li>
-        <li>Flottants : <code>3.14</code>, <code>2.0e-3</code></li>
-        <li>Booléens : <code>true</code>, <code>false</code></li>
-        <li>Caractères : <code>'a'</code>, <code>'\n'</code></li>
-        <li>Chaînes : <code>"..."</code>, <code>r"..."</code></li>
-      </ul>
-
-      <h3>3.7 Bonnes pratiques de style</h3>
-      <p>Débutant : <code>let</code> + <code>println</code> · Intermédiaire : <code>assert</code>, <code>match</code> exhaustif · Pro : conversions explicites avec <code>as</code>.</p>
-
-      <p class="card"><strong>Résumé</strong> — Commentaires <code>//</code>/<code>/*...*/</code> · variables immuables par défaut (<code>mut</code> si besoin) · fonctions <code>fn</code> · contrôles <code>if</code>/<code>while</code>/<code>for</code> · <code>match</code> exhaustif.</p>
-    </section>
-
-    <hr />
-
-    <!-- 4) EXEMPLES -->
-    <section id="exemples">
-      <h2>4) Premiers exemples — détaillés</h2>
-      <p><strong>Objectif</strong> — Écrire, exécuter, compiler et tester trois programmes types, avec erreurs fréquentes et variantes.</p>
-      <p><strong>Pré-requis</strong> — Arbo conseillée : <code>/src</code> avec <code>main.vitl</code>, <code>cat.vitl</code>, <code>geom.vitl</code>.</p>
-
-      <h3>4.1 Débutant → programme minimal</h3>
-<pre><code>// src/main.vitl
-module app.main
-import std.io
-
-fn main() -&gt; i32 {
-  std.io::println("Bonjour Vitte Light")
-  return 0
-}
-</code></pre>
-<pre><code># Exécution (VM)
-vitl run src/main.vitl
-
-# Compilation (binaire)
-vitl build -O2 -o build/hello src/main.vitl
-./build/hello
-
-# Sortie attendue
-Bonjour Vitte Light
-</code></pre>
-      <ul>
-        <li>E0001 symbole inconnu : oublier <code>import std.io</code>.</li>
-        <li>E0002 types incompatibles : concaténer nombre + string sans <code>.to_string()</code>.</li>
-      </ul>
-<pre><code>// Variante A
-fn main() -&gt; i32 {
-  let n = 42
-  std.io::println("n=" + n.to_string())
-  return 0
-}
-
-// Variante B (codes d'erreur)
-fn main() -&gt; i32 {
-  if 2 + 2 != 4 {
-    std.io::eprintln("arithmétique cassée")
-    return 1
-  }
-  return 0
-}
-</code></pre>
-
-      <h3>4.2 Intermédiaire → lire un fichier</h3>
-<pre><code>// src/cat.vitl
-module app.cat
-import std.{fs, io, cli, str}
-
-fn main() -&gt; i32 {
-  let argv = cli::args()
-  if str::len(argv) &lt; 2 {
-    io::eprintln("usage: cat &lt;fichier&gt;")
-    return 2
-  }
-  let path = argv[1]
-  if !fs::exists(path) {
-    io::eprintln("introuvable:" + path)
-    return 3
-  }
-  let contenu = fs::read_to_string(path)?  // propage l'erreur I/O
-  io::print(contenu)
-  return 0
-}
-</code></pre>
-<pre><code># Exécution
-vitl run src/cat.vitl -- data.txt
-</code></pre>
-      <ul>
-        <li>OK : affiche le contenu.</li>
-        <li>Erreur d’usage : code 2.</li>
-        <li>Fichier manquant : code 3.</li>
-      </ul>
-<pre><code>// Variante A (binaire)
-let bytes = fs::read(path)?
-io::println("taille=" + bytes.len().to_string())
-
-// Variante B (chrono)
-let t0 = std.time::now()
-let contenu = fs::read_to_string(path)?
-io::println("ms=" + (std.time::now() - t0).to_string())
-
-// Variante C (multi-fichiers)
-for i in 1..str::len(argv) {
-  let p = argv[i]
-  if !fs::exists(p) { io::eprintln("skip:" + p); continue }
-  io::print(fs::read_to_string(p)?)
-}
-</code></pre>
-
-      <h3>4.3 Pro → struct, impl, méthodes</h3>
-<pre><code>// src/geom.vitl
-module app.geom
-import std.{io, math}
-
-struct Vec2 { x: f64, y: f64 }
-
-impl Vec2 {
-  fn norm(&amp;self) -&gt; f64 { return (self.x*self.x + self.y*self.y).sqrt() }
-  fn dot(&amp;self, o: Vec2) -&gt; f64 { return self.x*o.x + self.y*o.y }
-}
-
-fn main() -&gt; i32 {
-  let v = Vec2 { x: 3.0, y: 4.0 }
-  io::println(v.norm().to_string()) // 5
-  return 0
-}
-
-// Tests intégrés
-test "norm classique 3-4-5" {
-  let v = Vec2 { x:3.0, y:4.0 }
-  assert(v.norm() == 5.0)
-}
-test "dot produit orthogonal" {
-  let a = Vec2 { x:1.0, y:0.0 }
-  let b = Vec2 { x:0.0, y:1.0 }
-  assert(a.dot(b) == 0.0)
-}
-</code></pre>
-<pre><code>// Variante A (parse CLI)
-import std.{cli, str}
-fn parse_f64(s: str) -&gt; Result&lt;f64, str&gt; { return str::to_float(s) }
-fn main() -&gt; i32 {
-  let a = cli::args()
-  if str::len(a) != 3 {
-    io::eprintln("usage: geom &lt;x&gt; &lt;y&gt;"); return 2
-  }
-  let x = parse_f64(a[1])?
-  let y = parse_f64(a[2])?
-  let v = Vec2 { x:x, y:y }
-  io::println(v.norm().to_string())
-  return 0
-}
-
-// Variante B (mini-bench)
-fn bench(n: i32) -&gt; i32 {
-  let mut acc:f64 = 0.0
-  let base = Vec2 { x:1.234, y:5.678 }
-  for i in 0..n {
-    let v = Vec2 { x: base.x + (i as f64), y: base.y - (i as f64) }
-    acc = acc + v.norm()
-  }
-  std.io::println("acc=" + acc.to_string())
-  return 0
-}
-fn main() -&gt; i32 {
-  let t0 = std.time::now()
-  _ = bench(100000)
-  std.io::println("ms=" + (std.time::now()-t0).to_string())
-  return 0
-}
-</code></pre>
-
-      <h3>4.4 Bonnes pratiques transverses</h3>
-      <ul>
-        <li>Style : <code>module</code> en tête, imports groupés, <code>snake_case</code> pour fonctions/variables, <code>CamelCase</code> pour types.</li>
-        <li>Erreurs : <code>?</code> pour I/O et parsing, codes de sortie (0,1,2,3,4).</li>
-        <li>Organisation : un fichier = un module; tests en fin de fichier.</li>
-        <li>Perf : <code>time::now()</code>, slices <code>[T]</code>, <code>vec::with_capacity</code>.</li>
-        <li>Sécurité : pas d’<code>unsafe</code> hors FFI; utiliser <code>CString</code> pour le C.</li>
-      </ul>
-    </section>
-
-    <hr />
-
-    <!-- 5) MEMOIRE -->
-    <section id="memoire">
-      <h2>5) Mémoire et sécurité — guide détaillé</h2>
-
-      <h3>5.1 Modèle mémoire en mode sûr</h3>
-      <ul>
-        <li>Pas de GC complexe, gestion via références comptées <code>Rc&lt;T&gt;</code>.</li>
-        <li>Libération immédiate quand le compteur tombe à zéro.</li>
-      </ul>
-<pre><code>let a = Rc&lt;int&gt;::new(42)
-let b = a.clone()  // forts = 2
-a.drop()           // forts = 1
-b.drop()           // forts = 0 → libération
-</code></pre>
-      <p>Avantages : simplicité, déterminisme, sécurité. Limites : cycles <em>forts</em> non collectés → utiliser <code>Weak</code>.</p>
-
-      <h3>5.2 Immutabilité et mutabilité</h3>
-<pre><code>// str immuable ; String mutable
-let mut s = String::from("abc")
-s.push("d")  // "abcd"
-</code></pre>
-
-      <h3>5.3 Collections et slices</h3>
-<pre><code>let v:[i32] = [1,2,3,4]
-for x in &amp;v { io::println(x.to_string()) }
-</code></pre>
-      <p>Pré-allouer avec <code>vec::with_capacity</code> quand la taille est connue.</p>
-
-      <h3>5.4 Mode <code>unsafe</code> et pointeurs bruts</h3>
-<pre><code>extern "C" { fn puts(msg:*const char)-&gt;i32 }
-let cstr = std.c::CString::from_str("hi\n")?
-unsafe { puts(cstr.as_ptr()) }
-</code></pre>
-      <p>Encapsuler l’<code>unsafe</code> dans des fonctions VITL sûres.</p>
-
-      <h3>5.5 Par niveau</h3>
-      <p>Débutant : pas de <code>free()</code>, éviter <code>unsafe</code>. · Intermédiaire : <code>Rc/Weak</code>, slices, <code>str</code> vs <code>String</code>. · Pro : graphes via <code>Weak</code>, FFI encapsulé, allocateurs custom côté C si besoin.</p>
-
-      <h3>5.6 Erreurs courantes</h3>
-      <ul>
-        <li>Cycles <code>Rc</code> → fuite.</li>
-        <li>Passer une <code>String</code> temporaire au C → pointeur dangling.</li>
-        <li>Oublier <code>mut</code> → erreur compilation.</li>
-        <li><code>unsafe</code> non encapsulé.</li>
-      </ul>
-
-      <h3>5.7 Récapitulatif</h3>
-      <p>Gestion sûre via <code>Rc/Weak</code> · pas de GC · <code>str</code> immuable / <code>String</code> mutable · slices évitent les copies · <code>unsafe</code> réservé au FFI.</p>
-    </section>
-
-    <hr />
-
-    <!-- 6) ERREURS -->
-    <section id="erreurs">
-      <h2>6) Gestion des erreurs</h2>
-      <p>Type standard : <code>Result&lt;T, E&gt;</code> avec <code>Ok(T)</code> / <code>Err(E)</code>. Propagation avec <code>?</code>.</p>
-<pre><code>let contenu = fs::read_to_string("config.txt")?
-</code></pre>
-<pre><code>match fs::read_to_string("config.txt") {
-  Result::Ok(txt) =&gt; println(txt),
-  Result::Err(e)  =&gt; eprintln(e),
-}
-</code></pre>
-      <p><code>panic("msg")</code> : erreur irrécupérable, arrêt du programme.</p>
-    </section>
-
-    <hr />
-
-    <!-- 7) FFI -->
-    <section id="ffi">
-      <h2>7) Interopérabilité C (FFI) — guide avancé</h2>
-      <p>But — Appeler du code C en sécurité, définir un shim C portable, gérer chaînes/buffers/erreurs/édition de liens.</p>
-
-      <h3>7.1 Déclaration et appel minimal</h3>
-<pre><code>extern "C" { fn puts(msg: *const char) -&gt; i32 }
-let cstr = std.c::CString::from_str("Hello C!\n")?
-unsafe { _ = puts(cstr.as_ptr()) }
-
-// lien à la libc (ex.)
-vitl build -O2 -L libs -lc -o build/app src/main.vitl
-</code></pre>
-
-      <h3>7.2 Chaînes et ownership</h3>
-      <ul>
-        <li>Entrée VITL→C : construire via <code>CString::from_str</code>, conserver la durée de vie.</li>
-        <li>Retour C→VITL : copier si buffer interne, sinon libérer avec l’allocateur documenté (ex. <code>c::free</code>).</li>
-      </ul>
-
-      <h3>7.3 Buffers binaires et slices</h3>
-<pre><code>extern "C" { fn sha256(data:*const u8, len:usize, out:*mut u8) -&gt; i32 }
-let mut out:[u8] = [0; 32]
-unsafe { _ = sha256(input.as_ptr(), input.len(), out.as_mut_ptr()) }
-</code></pre>
-
-      <h3>7.4 Structs : opacité</h3>
-<pre><code>// C (shim)
-typedef struct Obj Obj;
-Obj* obj_create(int cap);
-void obj_destroy(Obj*);
-int  obj_push(Obj*, const char*);
-int  obj_len(const Obj*);
-
-// VITL
-extern "C" {
-  fn obj_create(cap:i32)-&gt;*mut void
-  fn obj_destroy(p:*mut void)-&gt;void
-  fn obj_push(p:*mut void, s:*const char)-&gt;i32
-  fn obj_len(p:*const void)-&gt;i32
-}
-</code></pre>
-
-      <h3>7.5 Erreurs et mapping <code>Result</code></h3>
-<pre><code>fn c_call_ok(code:i32) -&gt; Result&lt;(),str&gt; {
-  if code == 0 { return Result::Ok(()) }
-  return Result::Err("ffi: call failed")
-}
-</code></pre>
-
-      <h3>7.6 Callbacks et <code>user_data</code></h3>
-      <p>Gérer les callbacks dans le shim C, VITL fournit un identifiant opaque.</p>
-
-      <h3>7.7 Linking : <code>-L</code>, <code>-l</code>, rpath, static</h3>
-<pre><code># Dylib partagée
-vitl build -O2 -L libs -lfoo -o build/app src/main.vitl
-
-# Statique (si dispo)
-vitl build -O2 -L libs -Wl,-Bstatic -lfoo -Wl,-Bdynamic -o build/app src/main.vitl
-
-# rpath
-vitl build ... -Wl,-rpath,/chemin/vers/libs
-</code></pre>
-
-      <h3>7.8 Cross-plateforme</h3>
-      <p>Types stables (<code>int32_t</code>, <code>uint64_t</code>, <code>size_t</code>), éviter <code>long</code>, attention à l’alignement.</p>
-
-      <h3>7.9 Sécurité mémoire : règles d’or</h3>
-      <ul>
-        <li>Bornes vérifiées, pas de double free.</li>
-        <li>Chaînes null-terminées côté C.</li>
-        <li>Ne pas garder de pointeur C vers une <code>String</code> temporaire.</li>
-      </ul>
-
-      <h3>7.10 Exemple complet : wrapper « safe »</h3>
-<pre><code>// C (shim libfoo)
-typedef struct Foo Foo;
-Foo* foo_create(int cap); void foo_destroy(Foo*);
-int foo_push(Foo*, const char*); int foo_len(const Foo*);
-
-// VITL
-extern "C" {
-  fn foo_create(cap:i32)-&gt;*mut void
-  fn foo_destroy(h:*mut void)-&gt;void
-  fn foo_push(h:*mut void, s:*const char)-&gt;i32
-  fn foo_len(h:*const void)-&gt;i32
-}
-struct Foo { handle:*mut void }
-fn Foo::new(cap:i32) -&gt; Result&lt;Foo,str&gt; {
-  let h = unsafe { foo_create(cap) }
-  if h == std.ptr::null_mut() { return Result::Err("ffi: create failed") }
-  return Result::Ok(Foo{ handle:h })
-}
-fn Foo::push(&amp;mut self, s:str) -&gt; Result&lt;(),str&gt; {
-  let cstr = std.c::CString::from_str(s)?
-  let rc = unsafe { foo_push(self.handle, cstr.as_ptr()) }
-  if rc != 0 { return Result::Err("ffi: push failed") }
-  return Result::Ok(())
-}
-fn Foo::len(&amp;self) -&gt; i32 { return unsafe { foo_len(self.handle) } }
-fn Foo::close(&amp;mut self) -&gt; () {
-  if self.handle != std.ptr::null_mut() {
-    unsafe { foo_destroy(self.handle) }
-    self.handle = std.ptr::null_mut()
-  }
-}
-</code></pre>
-
-      <h3>7.11 Stratégie d’équipe et CI</h3>
-      <p>Figer l’interface C, tests d’intégration, builder shim + exécutable, publier artefacts (lib+header+sha), documenter rpath/paths.</p>
-
-      <h3>7.12 Quand FFI n’est pas le bon outil</h3>
-      <p>Regrouper les appels (batch), formats binaires compacts, runtime externe pour threads natifs.</p>
-
-      <p class="card"><strong>Résumé</strong> — ABI C, handles opaques, <code>CString</code>, <code>ptr+len</code>, <code>Result</code>, surface <code>unsafe</code> minimale.</p>
-    </section>
-
-    <hr />
-
-    <!-- 8) STDLIB -->
-    <section id="stdlib">
-      <h2>8) Stdlib — aperçu détaillé</h2>
-      <p>Convention — Fonctions système retournent <code>Result&lt;...&gt;</code>, <code>?</code> propage. Extraits supposent : <code>import std.{io, fs, str, math, time, cli, vec, debug, err, c}</code>.</p>
-
-      <h3>8.1 std.io — E/S console</h3>
-      <p>API : <code>print</code>, <code>println</code>, <code>eprint</code>, <code>eprintln</code>.</p>
-<pre><code>io::println("Hello")
-io::eprintln("fatal: config manquante")
-</code></pre>
-
-      <h3>8.2 std.fs — Fichiers et chemins</h3>
-<pre><code>let cfg = fs::read_to_string("config.toml")?
-_ = fs::write_string("out.txt", "ok\n")?
-if !fs::exists("data.bin") { io::eprintln("absent: data.bin"); return 3 }
-</code></pre>
-
-      <h3>8.3 std.str — Chaînes et utilitaires</h3>
-<pre><code>let n = str::len("abc")     // 3
-let parts = str::split("a b c", ' ')
-let idx = str::find("abc","b") // 1
-let out = str::replace("a_b","_","-") // "a-b"
-let v = str::to_int("42")?   // i64
-</code></pre>
-
-      <h3>8.4 std.math — Maths</h3>
-<pre><code>let d = math::sqrt(3.0*3.0 + 4.0*4.0) // 5.0
-let a = math::abs(-12) // 12
-</code></pre>
-
-      <h3>8.5 std.time — Horloge</h3>
-<pre><code>let t0 = time::now()
-heavy()
-io::println((time::now() - t0).to_string() + " ms")
-</code></pre>
-
-      <h3>8.6 std.cli — Arguments/env</h3>
-<pre><code>let argv = cli::args()
-if str::len(argv) &lt; 2 {
-  io::eprintln("usage: app &lt;file&gt;"); return 2
-}
-match cli::env("HOME") {
-  Some(h) =&gt; io::println(h),
-  None =&gt; io::eprintln("HOME non défini"),
-}
-</code></pre>
-
-      <h3>8.7 std.vec — Vecteurs</h3>
-<pre><code>let mut v:[i32] = vec::with_capacity(16)
-v.push(1); v.push(2)
-for x in &amp;v { io::println(x.to_string()) }
-match v.pop() { Some(x) =&gt; io::println("last="+x.to_string()), None =&gt; {} }
-</code></pre>
-
-      <h3>8.8 std.debug — Assertions</h3>
-<pre><code>debug::assert(sum([1,2,3]) == 6)
-debug::dump("state=INIT")
-</code></pre>
-
-      <h3>8.9 std.err — Erreurs</h3>
-      <p><code>err::Error</code> regroupe catégorie/message/contexte. Mapping vers codes de sortie conseillé.</p>
-
-      <h3>8.10 std.c — Pont C</h3>
-<pre><code>extern "C" { fn puts(msg:*const char) -&gt; i32 }
-let cmsg = c::CString::from_str("Hello\n")?
-unsafe { _ = puts(cmsg.as_ptr()) }
-</code></pre>
-
-      <h3>8.11 Patterns composés</h3>
-<pre><code>fn load_threshold(path: str) -&gt; Result&lt;i64, err::Error&gt; {
-  let s = fs::read_to_string(path)?
-  match str::to_int(str::replace(s, "\n", "")) {
-    Result::Ok(v) =&gt; return Result::Ok(v),
-    Result::Err(_) =&gt; return Result::Err(err::Error::new("parse int échoué")),
-  }
-}
-</code></pre>
-<pre><code>fn timed&lt;F&gt;(label: str, f: F) -&gt; ()
-where F: fn()-&gt;() {
-  let t0 = time::now()
-  f()
-  io::println(label + ":" + (time::now()-t0).to_string() + " ms")
-}
-</code></pre>
-
-      <h3>8.12 Conseils par niveau</h3>
-      <p>Débutant : io/fs/str/cli ; vérifier <code>exists</code>. · Intermédiaire : <code>Result</code> structuré, mesures. · Pro : shims C, <code>err::Error</code> centralisé, logs mesurés.</p>
-    </section>
-
-    <hr />
-
-    <!-- 9) STYLE -->
-    <section id="style">
-      <h2>9) Style et bonnes pratiques — guide détaillé</h2>
-
-      <h3>9.1 Structure générale des fichiers</h3>
-      <ol>
-        <li><strong>module</strong> en tête (ex. <code>module app.math.linear</code> pour <code>src/math/linear.vitl</code>).</li>
-        <li>Imports regroupés immédiatement après (par hiérarchie).</li>
-        <li>Ensuite : constantes → types → impl → fonctions → tests.</li>
-      </ol>
-
-      <h3>9.2 Nommage</h3>
-<pre><code>let user_name = "Alice"
-fn compute_area(w:i32, h:i32) -&gt; i32 { return w*h }
-
-struct Rectangle { width:i32, height:i32 }
-enum Status { Ok, Failed }
-</code></pre>
-
-      <h3>9.3 Constantes et immutabilité</h3>
-      <p>Toujours <code>const</code> pour les valeurs fixes ; immuable par défaut, <code>mut</code> au besoin.</p>
-    </section>
-
-    <hr />
-
-    <!-- 10) NIVEAUX -->
-    <section id="niveaux">
-      <h2>10) Conseils par niveau</h2>
-      <p><strong>Débutant</strong> : <code>println</code>, programmes &lt; 50 lignes, <code>vitl fmt</code>.</p>
-      <p><strong>Intermédiaire</strong> : <code>test</code>, <code>std.fs</code>, maîtriser <code>?</code>.</p>
-      <p><strong>Pro</strong> : FFI C, <code>-O3</code>, <code>--emit-ir</code>, CI/CD.</p>
-    </section>
-
-    <hr />
-
-    <!-- 11) LIMITES -->
-    <section id="limites">
-      <h2>11) Limites (version Light) — version détaillée</h2>
-      <p>Résumé : pas de threads natifs · pas de GC complet (Rc/Weak) · génériques partiels · FFI limité au C.</p>
-
-      <h3>11.1 Pas de threads natifs</h3>
-      <p>Stratégies : séquencer, multi-processus via FFI, pipelines, runtime externe.</p>
-
-      <h3>11.2 Pas de GC complet (Rc/Weak)</h3>
-      <p>Éviter les cycles forts, utiliser <code>Weak</code> pour liens retour, auditer les graphes.</p>
-
-      <h3>11.3 Génériques partiels</h3>
-      <p>Favoriser types concrets, interfaces de données, déporter la généricité lourde via FFI si critique.</p>
-
-      <h3>11.4 FFI limité au C (ABI C)</h3>
-      <p>Shim C requis pour C++/Rust/Go, API plate, handles opaques, responsabilités d’allocation documentées.</p>
-
-      <h3>11.5 Décider quand « sortir »</h3>
-      <p>Algorithme suffisant → rester VITL ; contraintes structurelles → isoler via lib externe + FFI.</p>
-
-      <h3>11.6 Contrats de qualité</h3>
-      <p>Tests (succès/erreur), logs contextualisés, docs <code>///</code>, micro-benchs I/O/FFI.</p>
-    </section>
-
-    <hr />
-
-    <!-- 12) CODES -->
-    <section id="codes-sortie">
-      <h2>12) Codes de sortie</h2>
-      <ul>
-        <li><strong>0</strong> → succès</li>
-        <li><strong>1</strong> → erreur générique/panic</li>
-        <li><strong>2</strong> → erreur d’usage CLI</li>
-        <li><strong>3</strong> → erreur I/O</li>
-        <li><strong>4</strong> → erreur FFI</li>
-      </ul>
-    </section>
-
-    <hr />
-
-    <!-- 13) DIAGNOSTICS -->
-    <section id="diagnostics">
-      <h2>13) Diagnostics courants — version détaillée</h2>
-      <p><strong>Outils</strong> : <code>vitl check</code> · <code>vitl build -g -O0</code> · <code>--emit-ir</code>/<code>--emit-bytecode</code> · <code>std.debug::backtrace()</code> · <code>vitl doc</code></p>
-
-      <h3>E0001 : symbole inconnu</h3>
-<pre><code>// Mauvais
-module app.main
-fn main()-&gt;i32 {
-  std.io::pritnln("hi")
-  return 0
-}
-
-// Correct
-module app.main
-import std.io
-fn main()-&gt;i32 {
-  std.io::println("hi")
-  return 0
-}
-</code></pre>
-
-      <h3>E0002 : types incompatibles</h3>
-<pre><code>// Mauvais
-let n:i32 = 3
-let x:f64 = 0.5
-let y = n + x
-
-// Correct (cast local)
-let n:i32 = 3
-let x:f64 = 0.5
-let y = (n as f64) + x
-
-// Chaînes
-std.io::println("n=" + n)           // E0002
+collecte de cycles automatique.
+
+Conséquences --- Les cycles forts (A → B → A) **ne sont pas libérés**
+automatiquement. --- Les performances sont prévisibles (pas de pause
+GC), mais l'architecture doit éviter les cycles.
+
+Stratégies de conception Débutant --- Préférer des structures
+arborescentes sans références en arrière. --- Passer des données par
+valeur quand c'est petit et fréquent (i32, f64...).
+
+Intermédiaire --- Utiliser **Weak** pour les pointeurs "retour" (parent)
+et **Rc** pour les pointeurs "avant" (enfants). --- Documenter la
+topologie (qui possède quoi). Une seule direction en **fort**, l'autre
+en **faible**.
+
+Pro --- Introduire des *zones de vie* et des frontières claires entre
+propriétaires et observateurs. --- Auditer régulièrement (revue de code)
+les graphes d'objets susceptibles de former des cycles. --- Si
+nécessaire, encapsuler un allocateur/arena côté C via FFI pour des
+patterns haute fréquence (pools, slab).
+
+Exemple (rupture de cycle) Mauvais (cycle fort): // A::child -\>
+Rc`<B>`{=html}, B::parent -\> Rc`<A>`{=html} (cycle) Correct (parent
+faible): // A::child -\> Rc`<B>`{=html}, B::parent -\> Weak`<A>`{=html}
+
+Checklist \[ \] Les relations parents/enfants évitent-elles les cycles
+forts ?\
+\[ \] Les valeurs volumineuses sont-elles partagées via Rc et lues
+majoritairement ?\
+\[ \] Les buffers temporaires élevés en fréquence sont-ils réutilisés
+(éviter l'allocation répétée) ?
+
+─────────────────────────────────────────────── 11.3 Génériques partiels
+uniquement ────────────────────────────────── Ce que cela signifie ---
+Les types/génériques existent de façon limitée (principalement dans la
+stdlib). --- Moins de métaprogrammation que dans Vitte "complet" ou
+Rust.
+
+Conséquences --- API "générique" parfois moins flexible. --- Possibles
+duplications de code quand les types varient beaucoup.
+
+Stratégies de conception Débutant --- Commencer avec des types concrets
+(i32, f64, String). Éviter d'abstraire trop tôt. --- Favoriser des
+fonctions simples et spécialisées.
+
+Intermédiaire --- Factoriser par **interfaces de données** (formats
+texte, lignes, enregistrements) au lieu de viser la généricité
+type-paramétrée. --- Utiliser des adaptateurs minces : convertisseurs
+`to_string()`, `parse()` côté std.str.
+
+Pro --- Déporter la généricité "lourde" dans une lib C/Rust accessible
+via FFI C (sur quelques points chauds seulement). --- Stabiliser vos
+**types de domaine** (DTO) et isoler les conversions aux frontières de
+module. --- Intégrer des tests de non-régression lors des changements de
+type.
+
+Checklist \[ \] Les fonctions publiques ont-elles des signatures
+**stables** et explicites ?\
+\[ \] Les conversions de types sont-elles centralisées et testées ?\
+\[ \] Les points nécessitant de la généricité forte sont-ils délégués à
+FFI si critique ?
+
+─────────────────────────────────────────────── 11.4 FFI limité au C
+(ABI C) ──────────────────────────── Ce que cela signifie --- Seule
+l'interface binaire C est supportée nativement. --- C++/Rust/Go/etc.
+doivent exposer un **shim C** (`extern "C"`) pour être appelés.
+
+Conséquences --- Pas de passage direct d'objets complexes non-C. ---
+Convention d'appel et représentation mémoire = C.
+
+Stratégies d'intégration Débutant --- S'en tenir aux appels simples :
+fonctions C pures, entrées/sorties primitives, buffers. --- Toujours
+construire les chaînes avec `std.c::CString::from_str` avant de passer
+au C.
+
+Intermédiaire --- Écrire un **shim C** propre : API plate, types opaques
+(`void*` + fonctions d'accès), fonctions `create()/destroy()`. ---
+Vérifier les codes retour et convertir vers `Result`.
+
+Pro --- Définir une **ABI stable** (semver) côté C, tests d'intégration
+croisés (VITL ↔ C). --- Mesurer l'overhead d'appels FFI et grouper les
+opérations pour amortir le coût. --- Gérer explicitement
+l'allocation/désallocation croisée (qui possède le buffer ? qui le
+libère ?).
+
+Exemple de pattern FFI C (shim): struct Obj; Obj\* obj_create(int cap);
+void obj_destroy(Obj*); int obj_push(Obj*, const char\* s); // 0=OK,
+\<0=err int obj_len(const Obj\*);
+
+VITL: extern "C" { fn obj_create(cap:i32)-\>*mut void fn
+obj_destroy(p:*mut void)-\>void fn obj_push(p:*mut void, s:*const
+char)-\>i32 fn obj_len(p:\*const void)-\>i32 } // Construire CString,
+appeler dans unsafe, vérifier codes retour.
+
+Checklist \[ \] Le shim expose-t-il uniquement des types C stables (int,
+double, void*, char*) ?\
+\[ \] Les responsabilités d'allocation/libération sont-elles documentées
+?\
+\[ \] Chaque appel renvoie-t-il un code d'erreur testable, converti en
+`Result` côté VITL ?
+
+─────────────────────────────────────────────── 11.5 Décider quand
+"sortir" des limites ───────────────────────────────────────────── Règle
+pratique --- Si la fonctionnalité manque et que l'**algorithme** suffit
+à compenser → rester 100% VITL. --- Si les contraintes sont
+structurelles (threads, généricité lourde, GC) → **isoler** la partie
+critique dans une lib C/Rust avec shim C et piloter depuis VITL.
+
+Matrice rapide --- Performance CPU brute → déléguer le cœur à C/Rust
+(FFI).\
+--- I/O intensif séquentiel → VITL convient, optimiser le format et les
+buffers.\
+--- Concurrence massive → multi-processus ou runtime externe via FFI.\
+--- Modèles de données dynamiques et très polymorphes → fixer des DTO
+stables + shims.
+
+─────────────────────────────────────────────── 11.6 Contrats de qualité
+autour des limites ──────────────────────────────────────────── ---
+Tests : pour chaque contour, fournir au moins 1 test succès + 1 test
+erreur. --- Logs : enrichir les messages d'erreur avec contexte
+(fichier, taille, chemin). --- Docs : annoter les fonctions "limites"
+avec `///` précisant invariants et coûts. --- Bench : garder un
+micro-benchmark des chemins FFI et des I/O.
+
+Fin de la section 11.
+
+──────────────────────────────────────────────
+
+12) CODES DE SORTIE ──────────────────── 0 → succès\
+    1 → erreur générique/panic\
+    2 → erreur d'usage CLI\
+    3 → erreur I/O\
+    4 → erreur FFI
+
+────────────────────────────────────────────── 11) DIAGNOSTICS COURANTS
+--- VERSION DÉTAILLÉE ────────────────────────────────────────────
+
+But --- Donner pour chaque code : symptôme, causes probables,
+correctifs, exemples. --- Cible débutants → comprendre le message.
+Intermédiaires → corriger vite. Pros → outillage.
+
+Outils utiles --- Lint : vitl check src/ --- Build debug : vitl build -g
+-O0 -o build/app src/main.vitl --- IR/BC : vitl build --emit-ir \| vitl
+build --emit-bytecode --- Traces : std.debug::backtrace() \|
+panic("msg") --- Recherche : vitl doc src/ -o build/docs.txt
+
+Notation --- « Mauvais » = exemple fautif. « Correct » = correction
+minimale.
+
+E0001 : symbole inconnu ─────────────────────── Symptôme --- Le
+compilateur ne trouve pas une fonction, un type, un module ou une
+constante.
+
+Causes fréquentes --- Import manquant ou chemin de module incorrect. ---
+Typo dans le nom (majuscules/minuscules). --- Déplacement de fichier
+sans mise à jour de `module` en tête. --- API renommée lors d'une
+refactorisation.
+
+Correctifs standard --- Ajouter l'import précis ou corriger le chemin.
+--- Vérifier que `module` en tête correspond au chemin disque. ---
+Lancer `vitl fmt` pour regrouper et stabiliser les imports.
+
+Exemples Mauvais: module app.main fn main()-\>i32 {
+std.io::pritnln("hi") // typo return 0 }
+
+Correct: module app.main import std.io fn main()-\>i32 {
+std.io::println("hi") return 0 }
+
+Astuce pro --- Préférer `import std.{io, fs}` pour expliciter le
+périmètre. --- `vitl check` pointe la ligne et la colonne exactes.
+
+E0002 : types incompatibles ─────────────────────────── Symptôme --- Une
+expression du type A est passée là où B est attendu.
+
+Causes fréquentes --- Addition mélangeant `i32` et `f64`. --- Appel
+d'API avec paramètre de type attendu différent. --- Comparaison stricte
+entre types non convertibles.
+
+Correctifs standard --- Ajouter un cast explicite `as` quand la perte
+d'info est acceptée. --- Adapter la signature de la fonction ou
+l'appelant pour unifier les types. --- Introduire une conversion
+préalable (ex. `to_string()`).
+
+Exemples Mauvais: let n:i32 = 3 let x:f64 = 0.5 let y = n + x // E0002
+
+Correct (1 --- cast local): let n:i32 = 3 let x:f64 = 0.5 let y = (n as
+f64) + x
+
+Correct (2 --- normaliser l amont): let n:f64 = 3.0 let x:f64 = 0.5 let
+y = n + x
+
+Autres patterns --- Chaînes: std.io::println("n=" + n) // E0002
 std.io::println("n=" + n.to_string()) // OK
-</code></pre>
 
-      <h3>E0003 : variable non initialisée</h3>
-<pre><code>// Mauvais
-let mut acc:i32
-if cond { acc = 1 }
+Astuce pro --- Stabiliser les types aux frontières d'API publiques
+(types explicites). --- `vitl check` repère aussi les conversions
+implicites dangereuses.
+
+E0003 : variable non initialisée ────────────────────────────────
+Symptôme --- Utilisation d'une variable qui n'a pas reçu de valeur sur
+tous les chemins.
+
+Causes fréquentes --- Déclaration séparée de l'initialisation. ---
+Chemin `if/else` non exhaustif. --- Retour prématuré avant affectation.
+
+Correctifs standard --- Initialiser à la déclaration. --- Rendre les
+branches exhaustives. --- Restructurer en `match` pour couvrir tous les
+cas.
+
+Exemples Mauvais: let mut acc:i32 if cond { acc = 1 } // cond=false →
+acc non assignée std.io::println(acc.to_string()) // E0003
+
+Correct: let mut acc:i32 = 0 if cond { acc = 1 }
 std.io::println(acc.to_string())
 
-// Correct
-let mut acc:i32 = 0
-if cond { acc = 1 }
-std.io::println(acc.to_string())
-</code></pre>
+Autre: let x:i32 if a { x = 1 } else { x = 2 } // ici OK car exhaustif
 
-      <h3>E1001 : FFI non-safe hors <code>unsafe</code></h3>
-<pre><code>// Mauvais
-extern "C" { fn puts(msg:*const char)-&gt;i32 }
-fn main()-&gt;i32 {
-  let s = std.c::CString::from_str("Hi\n")
-  puts(s.as_ptr())  // E1001
-  return 0
-}
+Astuce pro --- Éviter les « variables sentinelles »; préférer un `match`
+retournant une valeur.
 
-// Correct
-extern "C" { fn puts(msg:*const char)-&gt;i32 }
-fn main()-&gt;i32 {
-  let s = std.c::CString::from_str("Hi\n")
-  unsafe { _ = puts(s.unwrap().as_ptr()) }
-  return 0
-}
-</code></pre>
+E1001 : appel FFI non-safe hors bloc unsafe
+──────────────────────────────────────────── Symptôme --- Appel d'une
+fonction C ou manipulation de pointeurs bruts sans `unsafe`.
 
-      <h3>E2001 : fichier introuvable (I/O)</h3>
-<pre><code>// Correct
-let path = "data/config.txt"
-if !std.fs::exists(path) {
-  std.io::eprintln("config manquante:" + path)
-  return 3
-}
-let txt = std.fs::read_to_string(path)?
-</code></pre>
+Causes fréquentes --- Oubli du bloc `unsafe { ... }`. --- Conversion de
+chaîne en `CString` non vérifiée. --- Passage d'un pointeur invalide à
+une API C.
 
-      <h3>Annexe A — Diagnostics supplémentaires</h3>
-      <ul>
-        <li>E0100 : variable non utilisée → supprimer ou préfixer <code>_</code>.</li>
-        <li>E0101 : code inatteignable → retirer ou factoriser.</li>
-        <li>E0201 : division par zéro détectable.</li>
-        <li>E0301 : dépassement d’index → tester <code>i &lt; v.len()</code> ou <code>get(i)</code>.</li>
-        <li>E0401 : <code>match</code> non exhaustif.</li>
-        <li>E0501 : conflit de mutabilité.</li>
-        <li>E0601 : format de chaîne invalide (manque <code>to_string()</code>).</li>
-        <li>E0701 : échec FFI (code &lt; 0).</li>
-        <li>E0801 : UTF-8 invalide en lecture texte.</li>
-      </ul>
+Correctifs standard --- Envelopper *uniquement* l'appel risqué dans
+`unsafe`. --- Construire les `CString` via `std.c::CString::from_str`.
+--- Assurer la durée de vie des buffers passés au C.
 
-      <h3>Annexe B — Stratégie de triage</h3>
-      <ol>
-        <li>Lire le message complet et la ligne.</li>
-        <li><code>vitl check</code> pour lints.</li>
-        <li>Vérifier <code>module</code>/<code>import</code>.</li>
-        <li>Normaliser/caster les types.</li>
-        <li>Initialiser à la déclaration / branches exhaustives.</li>
-        <li>FFI : <code>unsafe</code> + pointeurs/durées validés.</li>
-        <li>I/O : <code>exists</code>, chemins, droits.</li>
-        <li>Rebuild <code>-g</code> + backtrace.</li>
-        <li>Tests minimaux pour reproduire.</li>
-        <li>Doc <code>///</code> cause + correctif.</li>
-      </ol>
+Exemples Mauvais: extern "C" { fn puts(msg:\*const char)-\>i32 } fn
+main()-\>i32 { let s = std.c::CString::from_str("Hi`\n`{=tex}")
+puts(s.as_ptr()) // E1001 return 0 }
 
-      <h3>Annexe C — Messages enrichis</h3>
-<pre><code>// I/O robuste
-let path = argv[1]
-if !std.fs::exists(path) {
-  std.io::eprintln("E2001: fichier introuvable → " + path)
-  std.io::eprintln("Astuce: lancer depuis la racine du projet ou passer un chemin absolu.")
-  return 3
-}
-</code></pre>
-<pre><code>// FFI robuste
-let msg = std.c::CString::from_str("ok\n")
-if msg.is_err() { return Result::Err("E0601: CString invalide (caractère nul)") }
-unsafe { _ = puts(msg.unwrap().as_ptr()) }
-</code></pre>
+Correct: extern "C" { fn puts(msg:\*const char)-\>i32 } fn main()-\>i32
+{ let s = std.c::CString::from_str("Hi`\n`{=tex}") unsafe { \_ =
+puts(s.as_ptr()) } return 0 }
 
-      <h3>Annexe D — Prévenir les diagnostics</h3>
-      <ul>
-        <li>Imports précis et groupés ; <code>vitl fmt</code> fréquent.</li>
-        <li>Types explicites aux frontières d’API.</li>
-        <li>Tests unitaires par module (succès/erreurs attendues).</li>
-        <li>Logs contextualisés avec codes d’erreur stables.</li>
-        <li><code>unsafe</code> minimal et documenté.</li>
-        <li>Préférer <code>Option</code>/<code>Result</code> aux sentinelles.</li>
-        <li>Valider l’entrée tôt ; fail fast.</li>
-      </ul>
-    </section>
+Astuce pro --- Réduire la surface `unsafe` au strict minimum. ---
+Valider les tailles et null-terminators côté VITL avant l'appel.
 
-    <hr />
+E2001 : fichier introuvable (I/O) ─────────────────────────────────
+Symptôme --- Échec d'ouverture/lecture d'un fichier par la stdlib
+(erreur au runtime).
 
-    <!-- 14) CHECKLIST -->
-    <section id="checklist">
-      <h2>14) Checklist avant de livrer</h2>
-      <ul>
-        <li>[ ] <code>module app.main</code> défini</li>
-        <li>[ ] <code>fn main()-&gt;i32</code> présent</li>
-        <li>[ ] imports réduits au nécessaire</li>
-        <li>[ ] <code>vitl test</code> passe</li>
-        <li>[ ] <code>build/app</code> généré dans <code>/build</code></li>
-      </ul>
-      <p class="note">FIN DU GUIDE</p>
-    </section>
+Causes fréquentes --- Chemin relatif interprété depuis un répertoire
+inattendu. --- Fichier non copié ou supprimé. --- Droits insuffisants,
+montage absent.
 
-  </main>
-</body>
-</html>
+Correctifs standard --- Tester l'existence avant lecture. --- Utiliser
+des chemins absolus pour les ressources système. --- Gérer l'erreur avec
+`Result` et message contextuel.
+
+Exemples Mauvais: let txt = std.fs::read_to_string("data/config.txt")?
+// E2001
+
+Correct: let path = "data/config.txt" if !std.fs::exists(path) {
+std.io::eprintln("config manquante:" + path) return 3 } let txt =
+std.fs::read_to_string(path)?
+
+Annexe A --- Diagnostics supplémentaires courants
+─────────────────────────────────────────────── E0100 : variable non
+utilisée --- Contexte: le code compile mais une variable n est jamais
+lue. --- Correction: supprimer la variable, ou prefixer `_var` pour
+marquer volontaire.
+
+E0101 : code inatteignable --- Contexte: instructions après `return` ou
+après un `match` exhaustif. --- Correction: retirer la portion morte ou
+factoriser les branches.
+
+E0201 : division par zéro détectable --- Contexte: `x / 0` littéral
+connu au compile-time. --- Correction: vérifier dénominateur, valider en
+amont.
+
+E0301 : dépassement d'index (runtime) --- Contexte: `v[i]` hors bornes.
+--- Correction: tester `i < v.len()`, ou utiliser `get(i)` qui retourne
+`Option`.
+
+E0401 : pattern `match` non exhaustif --- Contexte: manque un cas,
+surtout avec `enum`. --- Correction: ajouter `_ => {...}` ou toutes les
+variantes.
+
+E0501 : conflit mutabilité simple --- Contexte: tentative d'écrire dans
+une donnée non `mut`. --- Correction: déclarer `let mut x` ou
+cloner/retourner une nouvelle valeur.
+
+E0601 : format de chaîne invalide --- Contexte: concat de types
+non-string sans `to_string()`. --- Correction: convertir avant
+concaténation.
+
+E0701 : échec FFI (résultat négatif) --- Contexte: fonction C renvoie
+code erreur. --- Correction: vérifier le code retour, convertir en
+`Result::Err(...)` côté VITL.
+
+E0801 : UTF-8 invalide lors d une lecture texte --- Contexte: contenu
+binaire lu via `read_to_string`. --- Correction: utiliser `std.fs::read`
+(bytes) puis décoder conditionnellement.
+
+Annexe B --- Stratégie de triage (checklist rapide)
+────────────────────────────────────────────────── 1) Lire le message
+complet et la ligne ciblée. 2) Lancer `vitl check` pour lints
+supplémentaires. 3) Si import/symbole: vérifier `module` et `import`. 4)
+Si types: normaliser les types en amont, cast explicite si nécessaire.
+5) Si non initialisé: initialiser à la déclaration ou rendre les
+branches exhaustives. 6) Si FFI: entourer par `unsafe`, valider les
+pointeurs et durées de vie. 7) Si I/O: controler `std.fs::exists`,
+chemins absolus, droits. 8) Recompiler avec `-g` et activer
+`std.debug::backtrace()` en cas de crash. 9) Ajouter des `test` minimaux
+pour reproduire le bug. 10) Documenter la cause et le correctif en
+commentaire `///` si API publique.
+
+Annexe C --- Exemples de messages enrichis côté application
+────────────────────────────────────────────────────────── --- I/O
+robuste: let path = argv\[1\] if !std.fs::exists(path) {
+std.io::eprintln("E2001: fichier introuvable →" + path)
+std.io::eprintln("Astuce: lancer depuis la racine du projet ou passer un
+chemin absolu.") return 3 }
+
+--- FFI robuste: let msg = std.c::CString::from_str("ok`\n`{=tex}") if
+msg.is_err() { return Result::Err("E0601: CString invalide (caractère
+nul)") } unsafe { \_ = puts(msg.unwrap().as_ptr()) }
+
+Annexe D --- Bonnes pratiques pour éviter les diagnostics
+──────────────────────────────────────────────────────── --- Imports
+précis et groupés; `vitl fmt` après chaque session. --- Types explicites
+aux frontières d'API (fonctions `pub`). --- Tests unitaires pour chaque
+module; couvrir les erreurs attendues. --- Logs de contexte avec codes
+d'erreur stables (E-codes ci-dessus). --- Limiter `unsafe` et l'isoler;
+documenter les invariants attendus. --- Préférer `Option`/`Result` aux
+valeurs sentinelles magiques. --- Valider l'entrée utilisateur tôt; fail
+fast avec message clair.
+
+Fin de la section 10.
+
+14) CHECKLIST AVANT DE LIVRER ───────────────────────────── \[ \] module
+    app.main défini\
+    \[ \] fn main()-\>i32 présent\
+    \[ \] imports réduits au nécessaire\
+    \[ \] vitl test passe avec succès\
+    \[ \] build/app généré dans /build
+
+──────────────────────────────────────────────
+
+FIN DU GUIDE ─────────────────────────────────────────────


### PR DESCRIPTION
Pull Request — Description complète
Résumé

Ajoute la documentation complète de VITTE LIGHT en français, en deux formats complémentaires :

doc.md : rendu optimal dans GitHub Markdown (sans <head>/<style>).

doc.html : version HTML autonome avec styles intégrés, prête pour GitHub Pages.

Motivation

Offrir un guide clair pour débutants, intermédiaires et pros.

Permettre la lecture directe dans le repo (MD) et une version présentable/publication via Pages (HTML).

Contenu principal

Introduction, philosophie, cas d’usage.

Structure de projet, CLI, syntaxe pas-à-pas.

Exemples (débutant → pro), mémoire & sécurité.

Erreurs/diagnostics, FFI C, stdlib, style & bonnes pratiques.

Limites, codes de sortie, checklist finale.

Nettoyage des extraits pour un rendu Markdown correct (pas de balises interdites, pas de blocs de code involontaires).

Changements

docs/doc.md — nouveau (compatible GitHub, sans CSS interne).

docs/doc.html — nouveau (HTML complet avec <head>/<style>).

(Optionnel) docs/ configuré comme racine GitHub Pages.

Comment vérifier

Aperçu MD : ouvrir docs/doc.md dans l’UI GitHub → vérifier que les sections et ancres s’affichent, pas le code source HTML.

Aperçu HTML (local) : ouvrir docs/doc.html dans un navigateur → vérifier typographie, couleurs, TOC.

GitHub Pages (si activé) : Settings → Pages → Deploy from branch (/docs) → visiter l’URL publiée.

Compatibilité & risques

Aucune rupture de build; uniquement des fichiers doc.

Rendu GitHub MD : pas de CSS custom (comportement attendu).

HTML isolé, sans dépendance externe.

Checklist

 Liens internes (#intro, #structure, …) valides dans doc.md.

 Pas de balises <style>/<head>/<html> dans doc.md.

 doc.html valide W3C (basique) et lisible en dark/light.

 (Optionnel) Pages activé sur /docs.